### PR TITLE
Potential fix for code scanning alert no. 1: DOM text reinterpreted as HTML

### DIFF
--- a/src/frontend/src/pages/DetailPage.tsx
+++ b/src/frontend/src/pages/DetailPage.tsx
@@ -74,7 +74,16 @@ export const DetailPage: React.FC = () => {
 
   const getReadmeUrl = () => {
     if (!action) return '';
-    const version = selectedVersion || 'main';
+
+    const availableVersions = action.releaseInfo || [];
+    let version = 'main';
+
+    if (selectedVersion && availableVersions.includes(selectedVersion)) {
+      version = selectedVersion;
+    } else if (availableVersions.length > 0) {
+      version = availableVersions[0];
+    }
+
     return `https://github.com/${action.owner}/${action.name}/blob/${version}/README.md`;
   };
 


### PR DESCRIPTION
Potential fix for [https://github.com/devops-actions/alternative-github-actions-marketplace/security/code-scanning/1](https://github.com/devops-actions/alternative-github-actions-marketplace/security/code-scanning/1)

In general, the fix is to ensure that untrusted DOM-derived values used to construct URLs are validated/normalized before being embedded, so that only expected-safe values are allowed. For this case, `selectedVersion` should be restricted to the known list of versions from `action.releaseInfo` and rejected/sanitized if it’s not in that list, rather than using any arbitrary string from the DOM.

The single best fix here without changing observable functionality is to update `getReadmeUrl` so that it derives the effective version from `action.releaseInfo` instead of blindly trusting `selectedVersion`. Concretely:
- If there is no `action`, return an empty string as now.
- Compute `const availableVersions = action.releaseInfo || [];`.
- If `selectedVersion` is non-empty and is present in `availableVersions`, use it.
- Otherwise, fall back to a safe default (the first available release version or `'main'` as currently used).
- Then build the GitHub URL with this validated `version` value.

This keeps the UI behavior the same under normal circumstances (user picks a version from the dropdown, and we use it), but ensures that if `selectedVersion` is ever tampered with in the DOM or via unexpected data, it cannot cause arbitrary `src` values to be constructed; only values from `action.releaseInfo` will be honored. Implementation-wise, this only requires editing the `getReadmeUrl` function in `src/frontend/src/pages/DetailPage.tsx`; no new imports or helpers are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
