### PR TITLE
fix: update stale threshold to 9 months for last updated highlight

### DIFF
--- a/src/frontend/src/pages/DetailPage.tsx
+++ b/src/frontend/src/pages/DetailPage.tsx
@@ -114,7 +114,7 @@ export const DetailPage: React.FC = () => {
     const now = new Date();
     const days = Math.floor((now.getTime() - then.getTime()) / (1000 * 60 * 60 * 24));
 
-    if (days > 365) return 'stale';
+    if (days > 270) return 'stale';
     if (days > 90) return 'aged';
     return '';
   };


### PR DESCRIPTION
Fixes #20

The getAgeClass() function was using 365 days (12 months) as the threshold for the red 'stale' highlight, but the issue specifies it should trigger at 9+ months (~270 days).

## Changes
- src/frontend/src/pages/DetailPage.tsx: Changed stale threshold from days > 365 to days > 270

## Thresholds after fix
- **aged** (yellow): 90+ days (~3 months) — unchanged
- **stale** (red): 270+ days (~9 months) — was 365 days