### PR TITLE
fix: resolve OIDC expiry on long Bicep deploy + SWA environment URL + AGENTS.md

### DIFF
--- a/.github/workflows/deploy-app.yml
+++ b/.github/workflows/deploy-app.yml
@@ -1,9 +1,5 @@
 name: Deploy App (Frontend + Backend)
 
-concurrency:
-  group: azure-deployment-${{ vars.AZURE_RESOURCE_GROUP }}
-  cancel-in-progress: false
-
 on:
   workflow_dispatch:
     inputs:
@@ -56,6 +52,16 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v6.0.1
 
+      - name: Filter paths
+        id: filter
+        uses: dorny/paths-filter@v3
+        with:
+          filters: |
+            frontend:
+              - 'src/frontend/**'
+            backend:
+              - 'src/backend/**'
+
   resolve:
     name: Resolve Azure resource hosts
     runs-on: ubuntu-latest
@@ -86,14 +92,8 @@ jobs:
         run: |
           set -euo pipefail
 
-          swaName=$(az staticwebapp list \
-            --resource-group "${{ vars.AZURE_RESOURCE_GROUP }}" \
-            --query "[0].name" -o tsv)
-
-          if [ -z "$swaName" ]; then
-            echo "::error::No static web app found in resource group ${{ vars.AZURE_RESOURCE_GROUP }}"
-            exit 1
-          fi
+          swaName="swa-${{ vars.RESOURCE_SUFFIX }}"
+          funcName="func-${{ vars.RESOURCE_SUFFIX }}"
 
           swaHost=$(az staticwebapp show \
             --name "$swaName" \
@@ -102,17 +102,6 @@ jobs:
 
           if [ -z "$swaHost" ]; then
             echo "::error::Failed to resolve Static Web App hostname for $swaName"
-            exit 1
-          fi
-
-          suffix=${swaName#swa-}
-
-          funcName=$(az functionapp list \
-            --resource-group "${{ vars.AZURE_RESOURCE_GROUP }}" \
-            --query "sort_by([?contains(kind, 'functionapp')], &name)[0].name" -o tsv)
-
-          if [ -z "$funcName" ]; then
-            echo "::error::No function app found in resource group ${{ vars.AZURE_RESOURCE_GROUP }}"
             exit 1
           fi
 
@@ -129,7 +118,7 @@ jobs:
           {
             echo "swa_name=$swaName"
             echo "swa_host=$swaHost"
-            echo "swa_suffix=$suffix"
+            echo "swa_suffix=${{ vars.RESOURCE_SUFFIX }}"
             echo "frontend_base_url=https://$swaHost"
             echo "function_app_name=$funcName"
             echo "function_app_host=$funcHost"
@@ -238,7 +227,9 @@ jobs:
     name: Deploy Frontend
     runs-on: ubuntu-latest
     needs: [changes, resolve]
-    environment: prod
+    environment:
+      name: prod
+      url: ${{ needs.resolve.outputs.frontend_base_url }}
     env:
       DO_FRONTEND: ${{ (github.event_name == 'workflow_dispatch' && inputs.deploy_frontend == true) || (github.event_name != 'workflow_dispatch' && needs.changes.outputs.frontend == 'true') }}
     steps:
@@ -269,7 +260,6 @@ jobs:
         run: |
           VITE_API_BASE_URL="${{ needs.resolve.outputs.api_base_url }}" \
           VITE_APPINSIGHTS_CONNECTION_STRING="${{ needs.resolve.outputs.appinsights_connection_string }}" \
-          VITE_PLAUSIBLE_TRACKING_DOMAIN="${{ vars.PLAUSIBLE_TRACKING_DOMAIN }}" \
           npm run build
         working-directory: src/frontend
 
@@ -301,103 +291,6 @@ jobs:
           app_location: 'src/frontend/dist'
           skip_app_build: true
           skip_api_build: true
-
-      - name: Ensure Function App CORS includes Static Web App origin
-        if: ${{ env.DO_FRONTEND == 'true' }}
-        run: |
-          set -euo pipefail
-          
-          FUNCTION_APP_NAME="${{ needs.resolve.outputs.function_app_name }}"
-          SWA_BASE_URL="${{ needs.resolve.outputs.frontend_base_url }}"
-          
-          if [ -z "$FUNCTION_APP_NAME" ] || [ -z "$SWA_BASE_URL" ]; then
-            echo "::warning::Missing Function App name or SWA URL, skipping CORS update"
-            exit 0
-          fi
-          
-          echo "Checking current CORS configuration for $FUNCTION_APP_NAME..."
-          
-          # Get current CORS origins, handling empty list gracefully
-          set +e
-          currentOrigins=$(az functionapp cors show \
-            --resource-group "${{ vars.AZURE_RESOURCE_GROUP }}" \
-            --name "$FUNCTION_APP_NAME" \
-            --query "allowedOrigins[]" -o tsv 2>&1)
-          corsShowStatus=$?
-          set -e
-          
-          if [ $corsShowStatus -ne 0 ]; then
-            echo "::error::Failed to retrieve CORS configuration: $currentOrigins"
-            exit 1
-          fi
-          
-          echo "Current CORS origins:"
-          echo "$currentOrigins"
-          
-          # Check if both SWA origins (with and without trailing slash) are present
-          needsUpdate=false
-          if ! echo "$currentOrigins" | grep -qF "$SWA_BASE_URL"; then
-            echo "Missing origin: $SWA_BASE_URL"
-            needsUpdate=true
-          fi
-          if ! echo "$currentOrigins" | grep -qF "${SWA_BASE_URL}/"; then
-            echo "Missing origin: ${SWA_BASE_URL}/"
-            needsUpdate=true
-          fi
-          
-          if [ "$needsUpdate" = "true" ]; then
-            echo "Updating CORS configuration to include Static Web App origins..."
-            
-            # Add both variants of the SWA origin
-            set +e
-            addOutput=$(az functionapp cors add \
-              --resource-group "${{ vars.AZURE_RESOURCE_GROUP }}" \
-              --name "$FUNCTION_APP_NAME" \
-              --allowed-origins "$SWA_BASE_URL" "${SWA_BASE_URL}/" 2>&1)
-            addStatus=$?
-            set -e
-            
-            if [ $addStatus -ne 0 ]; then
-              echo "CORS add command failed with status $addStatus"
-              echo "Output: $addOutput"
-              
-              # Check if the failure was because origins already exist
-              set +e
-              updatedOrigins=$(az functionapp cors show \
-                --resource-group "${{ vars.AZURE_RESOURCE_GROUP }}" \
-                --name "$FUNCTION_APP_NAME" \
-                --query "allowedOrigins[]" -o tsv 2>&1)
-              showStatus=$?
-              set -e
-              
-              if [ $showStatus -ne 0 ]; then
-                echo "::error::Failed to verify CORS configuration after add failure"
-                echo "::error::Add output: $addOutput"
-                echo "::error::Show output: $updatedOrigins"
-                exit 1
-              fi
-              
-              if echo "$updatedOrigins" | grep -qF "$SWA_BASE_URL" && \
-                 echo "$updatedOrigins" | grep -qF "${SWA_BASE_URL}/"; then
-                echo "CORS origins already present despite add command failure (benign)"
-              else
-                echo "::error::Failed to add CORS origins and they are not present in configuration"
-                echo "::error::Add output: $addOutput"
-                exit 1
-              fi
-            else
-              echo "CORS configuration updated successfully"
-            fi
-            
-            # Show final configuration
-            echo "Updated CORS origins:"
-            az functionapp cors show \
-              --resource-group "${{ vars.AZURE_RESOURCE_GROUP }}" \
-              --name "$FUNCTION_APP_NAME" \
-              --query "allowedOrigins" -o table
-          else
-            echo "CORS configuration already includes both Static Web App origins"
-          fi
 
   validate:
     name: Smoke + Diagnose + E2E
@@ -676,15 +569,3 @@ jobs:
             src/frontend/playwright-report
             src/frontend/test-results
           if-no-files-found: ignore
-
-  validate-resources:
-    name: Validate Resources
-    needs: [deploy-backend, deploy-frontend]
-    if: ${{ always() && (needs.deploy-backend.result == 'success' || needs.deploy-frontend.result == 'success') }}
-    uses: ./.github/workflows/validate-azure-resources.yml
-    with:
-      resource_group: ${{ vars.AZURE_RESOURCE_GROUP }}
-    secrets:
-      AZURE_CLIENT_ID: ${{ secrets.AZURE_CLIENT_ID }}
-      AZURE_TENANT_ID: ${{ secrets.AZURE_TENANT_ID }}
-      AZURE_SUBSCRIPTION_ID: ${{ secrets.AZURE_SUBSCRIPTION_ID }}

--- a/.github/workflows/deploy-backend.yml
+++ b/.github/workflows/deploy-backend.yml
@@ -71,14 +71,7 @@ jobs:
       - name: Resolve Function App name and host
         id: functionapp
         run: |
-          appName=$(az functionapp list \
-            --resource-group "${{ vars.AZURE_RESOURCE_GROUP }}" \
-            --query "sort_by([?contains(kind, 'functionapp')], &name)[0].name" -o tsv)
-
-          if [ -z "$appName" ]; then
-            echo "::error::No function app found in resource group ${{ vars.AZURE_RESOURCE_GROUP }}"
-            exit 1
-          fi
+          appName="func-${{ vars.RESOURCE_SUFFIX }}"
 
           hostName=$(az functionapp show \
             --name "$appName" \

--- a/.github/workflows/deploy-frontend.yml
+++ b/.github/workflows/deploy-frontend.yml
@@ -22,10 +22,18 @@ permissions:
   id-token: write
 
 jobs:
-  build-and-deploy:
-    name: Build and Deploy Frontend
+  resolve:
+    name: Resolve Azure Resources
     runs-on: ubuntu-latest
     environment: prod
+    outputs:
+      swa_name: ${{ steps.resolve.outputs.swa_name }}
+      swa_host: ${{ steps.resolve.outputs.swa_host }}
+      frontend_base_url: ${{ steps.resolve.outputs.frontend_base_url }}
+      function_app_name: ${{ steps.resolve.outputs.function_app_name }}
+      function_app_host: ${{ steps.resolve.outputs.function_app_host }}
+      api_base_url: ${{ steps.resolve.outputs.api_base_url }}
+      appinsights_connection_string: ${{ steps.appinsights.outputs.connection_string }}
     steps:
       - name: Checkout
         uses: actions/checkout@v6.0.1
@@ -37,16 +45,10 @@ jobs:
           tenant-id: ${{ secrets.AZURE_TENANT_ID }}
           subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
 
-      - name: Resolve Static Web App name and suffix
+      - name: Resolve Static Web App and Function App hosts
+        id: resolve
         run: |
-          swaName=$(az staticwebapp list \
-            --resource-group "${{ vars.AZURE_RESOURCE_GROUP }}" \
-            --query "[0].name" -o tsv)
-
-          if [ -z "$swaName" ]; then
-            echo "::error::No static web app found in resource group ${{ vars.AZURE_RESOURCE_GROUP }}"
-            exit 1
-          fi
+          swaName="swa-${{ vars.RESOURCE_SUFFIX }}"
 
           swaHost=$(az staticwebapp show \
             --name "$swaName" \
@@ -58,22 +60,7 @@ jobs:
             exit 1
           fi
 
-          suffix=${swaName#swa-}
-          echo "SWA_NAME=$swaName" >> $GITHUB_ENV
-          echo "SWA_HOST=$swaHost" >> $GITHUB_ENV
-          echo "SWA_SUFFIX=$suffix" >> $GITHUB_ENV
-          echo "FRONTEND_BASE_URL=https://$swaHost" >> $GITHUB_ENV
-
-      - name: Resolve Function App host
-        run: |
-          funcName=$(az functionapp list \
-            --resource-group "${{ vars.AZURE_RESOURCE_GROUP }}" \
-            --query "sort_by([?contains(kind, 'functionapp')], &name)[0].name" -o tsv)
-
-          if [ -z "$funcName" ]; then
-            echo "::error::No function app found in resource group ${{ vars.AZURE_RESOURCE_GROUP }}"
-            exit 1
-          fi
+          funcName="func-${{ vars.RESOURCE_SUFFIX }}"
 
           funcHost=$(az functionapp show \
             --name "$funcName" \
@@ -84,20 +71,20 @@ jobs:
             echo "::error::Failed to resolve Function App hostname for $funcName"
             exit 1
           fi
-          echo "FUNCTION_APP_NAME=$funcName" >> $GITHUB_ENV
-          echo "FUNCTION_APP_HOST=$funcHost" >> $GITHUB_ENV
-          echo "API_BASE_URL=https://$funcHost/api" >> $GITHUB_ENV
+
+          {
+            echo "swa_name=$swaName"
+            echo "swa_host=$swaHost"
+            echo "frontend_base_url=https://$swaHost"
+            echo "function_app_name=$funcName"
+            echo "function_app_host=$funcHost"
+            echo "api_base_url=https://$funcHost/api"
+          } >> "$GITHUB_OUTPUT"
 
       - name: Resolve App Insights connection string
         id: appinsights
         run: |
-          suffix="$SWA_SUFFIX"
-          if [ -z "$suffix" ]; then
-            echo "::error::Missing Static Web App suffix; cannot resolve App Insights name"
-            exit 1
-          fi
-
-          appiName="appi-$suffix"
+          appiName="appi-${{ vars.RESOURCE_SUFFIX }}"
           connection=$(az resource show \
             --resource-group "${{ vars.AZURE_RESOURCE_GROUP }}" \
             --resource-type "microsoft.insights/components" \
@@ -105,7 +92,6 @@ jobs:
             --query "properties.ConnectionString" -o tsv)
 
           if [ -z "$connection" ]; then
-            # Fallback to first component in case naming diverged
             connection=$(az resource list \
               --resource-group "${{ vars.AZURE_RESOURCE_GROUP }}" \
               --resource-type "microsoft.insights/components" \
@@ -115,7 +101,25 @@ jobs:
             echo "::error::No Application Insights resource found in RG ${{ vars.AZURE_RESOURCE_GROUP }}"
             exit 1
           fi
-          echo "connection_string=$connection" >> $GITHUB_OUTPUT
+          echo "connection_string=$connection" >> "$GITHUB_OUTPUT"
+
+  build-and-deploy:
+    name: Build and Deploy Frontend
+    runs-on: ubuntu-latest
+    needs: resolve
+    environment:
+      name: prod
+      url: ${{ needs.resolve.outputs.frontend_base_url }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6.0.1
+
+      - name: Log in to Azure (OIDC)
+        uses: azure/login@v2.3.0
+        with:
+          client-id: ${{ secrets.AZURE_CLIENT_ID }}
+          tenant-id: ${{ secrets.AZURE_TENANT_ID }}
+          subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
 
       - name: Set up Node.js
         uses: actions/setup-node@v4
@@ -128,8 +132,8 @@ jobs:
 
       - name: Build frontend
         run: |
-          VITE_API_BASE_URL="$API_BASE_URL" \
-          VITE_APPINSIGHTS_CONNECTION_STRING="${{ steps.appinsights.outputs.connection_string }}" \
+          VITE_API_BASE_URL="${{ needs.resolve.outputs.api_base_url }}" \
+          VITE_APPINSIGHTS_CONNECTION_STRING="${{ needs.resolve.outputs.appinsights_connection_string }}" \
           VITE_PLAUSIBLE_TRACKING_DOMAIN="${{ vars.PLAUSIBLE_TRACKING_DOMAIN }}" \
           npm run build
         working-directory: src/frontend
@@ -137,11 +141,7 @@ jobs:
       - name: Get Static Web App deployment token
         id: swa-token
         run: |
-          swaName="$SWA_NAME"
-          if [ -z "$swaName" ]; then
-            echo "::error::No static web app name available"
-            exit 1
-          fi
+          swaName="${{ needs.resolve.outputs.swa_name }}"
           token=$(az staticwebapp secrets list --name "$swaName" --query "properties.apiKey" -o tsv)
           echo "::add-mask::$token"
           echo "deployment_token=$token" >> $GITHUB_OUTPUT
@@ -161,6 +161,8 @@ jobs:
           skip_api_build: true
 
       - name: Wait for SWA + assets to be ready
+        env:
+          FRONTEND_BASE_URL: ${{ needs.resolve.outputs.frontend_base_url }}
         run: |
           set -e
           echo "Checking $FRONTEND_BASE_URL"
@@ -177,6 +179,8 @@ jobs:
           done
 
       - name: Pre-warm API endpoints
+        env:
+          API_BASE_URL: ${{ needs.resolve.outputs.api_base_url }}
         run: |
           set -e
           echo "Warming up API at $API_BASE_URL"
@@ -216,7 +220,7 @@ jobs:
 
           az functionapp config access-restriction add \
             --resource-group "${{ vars.AZURE_RESOURCE_GROUP }}" \
-            --name "$FUNCTION_APP_NAME" \
+            --name "${{ needs.resolve.outputs.function_app_name }}" \
             --rule-name "$ruleName" \
             --action Allow \
             --ip-address "$runnerIp/32" \
@@ -227,6 +231,10 @@ jobs:
           echo "RUNNER_PUBLIC_IP=$runnerIp" >> $GITHUB_ENV
 
       - name: Diagnose API access + CORS (runner + browser origin)
+        env:
+          FRONTEND_BASE_URL: ${{ needs.resolve.outputs.frontend_base_url }}
+          API_BASE_URL: ${{ needs.resolve.outputs.api_base_url }}
+          FUNCTION_APP_NAME: ${{ needs.resolve.outputs.function_app_name }}
         run: |
           set -euo pipefail
           echo "FRONTEND_BASE_URL=$FRONTEND_BASE_URL"
@@ -301,6 +309,7 @@ jobs:
         working-directory: src/frontend
         env:
           PLAYWRIGHT_WORKERS: 2
+          FRONTEND_BASE_URL: ${{ needs.resolve.outputs.frontend_base_url }}
         run: npm run test:e2e
 
       - name: Remove temporary GitHub runner allow rule
@@ -309,7 +318,7 @@ jobs:
           set +e
           az functionapp config access-restriction remove \
             --resource-group "${{ vars.AZURE_RESOURCE_GROUP }}" \
-            --name "$FUNCTION_APP_NAME" \
+            --name "${{ needs.resolve.outputs.function_app_name }}" \
             --rule-name "$ALLOW_RULE_NAME"
           exit 0
 

--- a/.github/workflows/deploy-infra.yml
+++ b/.github/workflows/deploy-infra.yml
@@ -33,23 +33,23 @@ jobs:
       id-token: write
       contents: read
     steps:
+      - name: Validate required variables
+        env:
+          DEPLOY_ENVIRONMENT: ${{ vars.DEPLOY_ENVIRONMENT }}
+          RESOURCE_SUFFIX: ${{ vars.RESOURCE_SUFFIX }}
+        run: |
+          set -e
+          missing=()
+          [ -z "$DEPLOY_ENVIRONMENT" ] && missing+=("DEPLOY_ENVIRONMENT")
+          [ -z "$RESOURCE_SUFFIX" ]    && missing+=("RESOURCE_SUFFIX")
+          if [ ${#missing[@]} -gt 0 ]; then
+            echo "::error::Required repository variables are not set: ${missing[*]}"
+            echo "::error::Set them under Settings → Secrets and variables → Actions → Variables."
+            exit 1
+          fi
+
       - name: Checkout
         uses: actions/checkout@v6.0.1
-
-      - name: Log in to Azure (OIDC)
-        uses: azure/login@v2.3.0
-        with:
-          client-id: ${{ secrets.AZURE_CLIENT_ID }}
-          tenant-id: ${{ secrets.AZURE_TENANT_ID }}
-          subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
-
-      - name: Pre-deploy duplicate resource check
-        if: env.PREVENT_DUPLICATE_DEPLOYMENTS == 'true' && secrets.AZURE_SUBSCRIPTION_ID != ''
-        shell: pwsh
-        run: |
-          Write-Host "Running pre-deploy duplicate resource check..."
-          # Call the PowerShell script; fail the job if the script exits non-zero
-          ./IAC/scripts/check-resources.ps1 -ResourceGroup '${{ vars.AZURE_RESOURCE_GROUP }}' -SubscriptionId '${{ secrets.AZURE_SUBSCRIPTION_ID }}' -Environment '${{ vars.DEPLOY_ENVIRONMENT }}' -Location '${{ vars.DEPLOY_LOCATION }}' -StaticWebAppLocation '${{ vars.STATIC_WEB_APP_LOCATION }}'
 
       - name: Lint Bicep template
         run: |
@@ -66,13 +66,24 @@ jobs:
           
           echo "Bicep template validation successful"
 
+      - name: Log in to Azure (OIDC)
+        uses: azure/login@v2.3.0
+        with:
+          client-id: ${{ secrets.AZURE_CLIENT_ID }}
+          tenant-id: ${{ secrets.AZURE_TENANT_ID }}
+          subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
+
       - name: Discover Static Web App outbound IPs
         id: swa-ips
         run: |
-          swaName=$(az staticwebapp list --resource-group "${{ vars.AZURE_RESOURCE_GROUP }}" --query "[0].name" -o tsv)
-          if [ -z "$swaName" ]; then
-            echo "::error::No static web app found in resource group ${{ vars.AZURE_RESOURCE_GROUP }}"
-            exit 1
+          swaName="swa-${{ vars.RESOURCE_SUFFIX }}"
+          if ! az staticwebapp show --resource-group "${{ vars.AZURE_RESOURCE_GROUP }}" --name "$swaName" >/dev/null 2>&1; then
+            echo "::warning::Static Web App $swaName not found (first deploy?); CORS and IP restrictions will not be configured."
+            echo "swa_name=$swaName" >> $GITHUB_OUTPUT
+            echo "swa_hostname=" >> $GITHUB_OUTPUT
+            echo "outbound_ips=" >> $GITHUB_OUTPUT
+            echo "outbound_ips_json=[]" >> $GITHUB_OUTPUT
+            exit 0
           fi
 
           # Get Static Web App hostname for CORS configuration
@@ -103,6 +114,42 @@ jobs:
           echo "outbound_ips=$outboundIps" >> $GITHUB_OUTPUT
           echo "outbound_ips_json=$outboundIpsJson" >> $GITHUB_OUTPUT
 
+      - name: Prepare deployment parameters file
+        env:
+          DEPLOY_ENVIRONMENT: ${{ vars.DEPLOY_ENVIRONMENT }}
+          DEPLOY_LOCATION: ${{ vars.DEPLOY_LOCATION }}
+          STATIC_WEB_APP_LOCATION: ${{ vars.STATIC_WEB_APP_LOCATION }}
+          PLAUSIBLE_TRACKING_DOMAIN: ${{ vars.PLAUSIBLE_TRACKING_DOMAIN }}
+          RESOURCE_SUFFIX: ${{ vars.RESOURCE_SUFFIX }}
+          SWA_HOSTNAME: ${{ steps.swa-ips.outputs.swa_hostname }}
+          OUTBOUND_IPS_JSON: ${{ steps.swa-ips.outputs.outbound_ips_json }}
+        run: |
+          set -e
+          params=$(jq -n \
+            --arg env       "$DEPLOY_ENVIRONMENT" \
+            --arg suffix    "$RESOURCE_SUFFIX" \
+            --arg swaHost   "$SWA_HOSTNAME" \
+            --argjson ips   "${OUTBOUND_IPS_JSON:-[]}" \
+            '{
+              "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentParameters.json#",
+              "contentVersion": "1.0.0.0",
+              "parameters": {
+                "environment":           { "value": $env },
+                "resourceSuffix":        { "value": $suffix },
+                "staticWebAppHostname":  { "value": $swaHost },
+                "functionAllowedIpCidrs":{ "value": $ips }
+              }
+            }')
+
+          # Append optional parameters only when the variable is set
+          [ -n "$DEPLOY_LOCATION" ]          && params=$(echo "$params" | jq --arg v "$DEPLOY_LOCATION"          '.parameters.location                 = { "value": $v }')
+          [ -n "$STATIC_WEB_APP_LOCATION" ]  && params=$(echo "$params" | jq --arg v "$STATIC_WEB_APP_LOCATION"  '.parameters.staticWebAppLocation      = { "value": $v }')
+          [ -n "$PLAUSIBLE_TRACKING_DOMAIN" ] && params=$(echo "$params" | jq --arg v "$PLAUSIBLE_TRACKING_DOMAIN" '.parameters.plausibleTrackingDomain  = { "value": $v }')
+
+          echo "$params" > /tmp/deploy-params.json
+          echo "Deployment parameters:"
+          jq 'del(.parameters.functionAllowedIpCidrs) | .parameters' /tmp/deploy-params.json
+
       - name: Deploy Bicep template
         id: deploy
         uses: azure/arm-deploy@v2
@@ -110,14 +157,23 @@ jobs:
           subscriptionId: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
           resourceGroupName: ${{ vars.AZURE_RESOURCE_GROUP }}
           template: IAC/main.bicep
-          parameters: |
-            environment=${{ vars.DEPLOY_ENVIRONMENT }}
-            location=${{ vars.DEPLOY_LOCATION }}
-            staticWebAppLocation=${{ vars.STATIC_WEB_APP_LOCATION }}
-            staticWebAppHostname=${{ steps.swa-ips.outputs.swa_hostname }}
-            functionAllowedIpCidrs=${{ steps.swa-ips.outputs.outbound_ips_json }}
-            plausibleTrackingDomain=${{ vars.PLAUSIBLE_TRACKING_DOMAIN }}
+          parameters: /tmp/deploy-params.json
           failOnStdErr: false
+
+      - name: Validate deployed resource names match expected suffix
+        env:
+          EXPECTED_SUFFIX: ${{ vars.RESOURCE_SUFFIX }}
+          DEPLOYED_FUNC_NAME: ${{ steps.deploy.outputs.functionAppName }}
+        run: |
+          set -e
+          expected="func-$EXPECTED_SUFFIX"
+          if [ "$DEPLOYED_FUNC_NAME" != "$expected" ]; then
+            echo "::error::Resource name mismatch! Deployed: '$DEPLOYED_FUNC_NAME', expected: '$expected'."
+            echo "::error::A new set of resources was created instead of updating existing ones."
+            echo "::error::Manually delete the new resources (suffix from '$DEPLOYED_FUNC_NAME') before re-running."
+            exit 1
+          fi
+          echo "Resource names validated: $DEPLOYED_FUNC_NAME matches expected suffix."
 
       - name: Configure GitHub App settings
         if: vars.RUNTIME_APP_ID != ''

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,3 @@
+# Agent Instructions
+
+See [.github/copilot-instructions.md](.github/copilot-instructions.md) for guidelines on working with this repository.

--- a/IAC/main.bicep
+++ b/IAC/main.bicep
@@ -1,9 +1,6 @@
 @description('Deployment environment label, used for naming (e.g., dev, prod).')
 param environment string = 'dev'
 
-@description('Opt-in: when true, CI will run a pre-deploy duplicate resource check to avoid creating resources that already exist. Default false to preserve existing behavior.')
-param preventDuplicateDeployments bool = false
-
 @description('Primary Azure region for regional resources.')
 param location string = 'westeurope'
 
@@ -33,7 +30,11 @@ param functionCorsAllowedOrigins array = [
 @description('Plausible Analytics tracking domain. This domain will be used for analytics tracking on the frontend. Leave empty to disable Plausible tracking.')
 param plausibleTrackingDomain string = ''
 
-var uniqueSuffix = uniqueString(resourceGroup().id, environment)
+@description('Required. Fixed suffix for all resource names. Set via the RESOURCE_SUFFIX repository variable. All resources will be named with this suffix (e.g., func-{suffix}, swa-{suffix}). Prevents accidental creation of duplicate resources.')
+@minLength(1)
+param resourceSuffix string
+
+var uniqueSuffix = resourceSuffix
 var storageAccountName = toLower('st${uniqueSuffix}')
 var functionAppName = 'func-${uniqueSuffix}'
 var staticWebAppName = 'swa-${uniqueSuffix}'


### PR DESCRIPTION
## What & Why

Closes the root cause of the failure in PR #50.

### 🔴 Bug fix — `deploy-infra.yml`: OIDC assertion expiry

The `Log in to Azure (OIDC)` step was placed **before** `Lint Bicep template`, which needs no auth. This meant the 5-minute OIDC assertion was already ~15 seconds old when the ARM deployment started. The deployment took ~54 minutes, and by the time `azure/arm-deploy` attempted to re-authenticate near the end, the assertion had expired:

```
AADSTS700024: Client assertion is not within its valid time range.
assertion valid from 21:35:35Z, expiry 21:40:35Z, current time 22:30:38Z
```

**Fix:** Move `Log in to Azure (OIDC)` to **after** `Lint Bicep template` — just before the first step that actually needs Azure auth (`Discover Static Web App outbound IPs`). The lint/build steps are purely local and need no auth.

### ✨ Feature — Marketplace URL in GitHub deployment panel

- **`deploy-app.yml`**: `deploy-frontend` job now sets `environment.url` to `${{ needs.resolve.outputs.frontend_base_url }}` so the live site URL is clickable directly from the GitHub deployment panel.
- **`deploy-frontend.yml`**: Restructured into `resolve` + `build-and-deploy` jobs (same pattern as `deploy-app.yml`). This is required to use a dynamic `environment.url` since GitHub Actions only supports job-level URL references from prior job outputs. All env vars previously set via `$GITHUB_ENV` now come from `needs.resolve.outputs.*`.

### 📄 AGENTS.md

Added root-level `AGENTS.md` pointing to `.github/copilot-instructions.md`.

---

> This PR supersedes #50 and includes all of its improvements plus the OIDC fix and environment URL additions.