### PR TITLE
fix: resolve workflow file issues in swa-test and staged-deploy

### DIFF
--- a/.github/workflows/staged-deploy.yml
+++ b/.github/workflows/staged-deploy.yml
@@ -11,9 +11,6 @@ on:
     types: [opened, synchronize]
   workflow_dispatch: {}
 
-env:
-  AZURE_CREDENTIALS: ${{ secrets.AZURE_CREDENTIALS }}
-
 permissions:
   contents: read
   id-token: write
@@ -23,6 +20,23 @@ concurrency:
   cancel-in-progress: false
 
 jobs:
+  check-creds:
+    name: Check Azure credentials
+    runs-on: ubuntu-latest
+    outputs:
+      has_creds: ${{ steps.check.outputs.has_creds }}
+    steps:
+      - name: Check if AZURE_CREDENTIALS secret is set
+        id: check
+        env:
+          AZURE_CREDENTIALS: ${{ secrets.AZURE_CREDENTIALS }}
+        run: |
+          if [ -n "$AZURE_CREDENTIALS" ]; then
+            echo "has_creds=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "has_creds=false" >> "$GITHUB_OUTPUT"
+          fi
+
   build:
     name: Build
     runs-on: ubuntu-latest
@@ -51,9 +65,9 @@ jobs:
 
   deploy-staging:
     name: Deploy to Staging
-    needs: build
+    needs: [build, check-creds]
     runs-on: ubuntu-latest
-    if: github.event_name == 'push' && env.AZURE_CREDENTIALS != ''
+    if: github.event_name == 'push' && needs.check-creds.outputs.has_creds == 'true'
     steps:
       - name: Checkout
         uses: actions/checkout@v6.0.1
@@ -85,9 +99,9 @@ jobs:
 
   smoke-tests:
     name: Smoke tests against Staging
-    needs: deploy-staging
+    needs: [deploy-staging, check-creds]
     runs-on: ubuntu-latest
-    if: needs.deploy-staging.result == 'success' && env.AZURE_CREDENTIALS != ''
+    if: needs.deploy-staging.result == 'success' && needs.check-creds.outputs.has_creds == 'true'
     steps:
       - name: Checkout
         uses: actions/checkout@v6.0.1
@@ -109,9 +123,9 @@ jobs:
 
   promote-to-production:
     name: Promote to Production
-    needs: smoke-tests
+    needs: [smoke-tests, check-creds]
     runs-on: ubuntu-latest
-    if: github.event_name == 'push' && env.AZURE_CREDENTIALS != ''
+    if: github.event_name == 'push' && needs.check-creds.outputs.has_creds == 'true'
     environment: production
     steps:
       - name: Checkout
@@ -142,9 +156,11 @@ jobs:
 
   noop-on-missing-secrets:
     name: No-op guard for PRs or missing secrets
+    needs: check-creds
     runs-on: ubuntu-latest
-    if: env.AZURE_CREDENTIALS == ''
+    if: needs.check-creds.outputs.has_creds != 'true'
     steps:
       - name: Skip deploys (no Azure credentials)
         run: |
           echo "AZURE_CREDENTIALS missing; skipping deployment steps. This is expected for PRs or forks."
+

--- a/.github/workflows/swa-test.yml
+++ b/.github/workflows/swa-test.yml
@@ -11,6 +11,9 @@ on:
 jobs:
   build-and-test:
     runs-on: ubuntu-latest
+    env:
+      AZURE_WEBAPP_NAME: ${{ secrets.AZURE_WEBAPP_NAME }}
+      AZURE_CREDENTIALS: ${{ secrets.AZURE_CREDENTIALS }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -39,11 +42,11 @@ jobs:
         run: npm run build
 
       - name: Skip deployment (no Azure secrets)
-        if: ${{ !secrets.AZURE_WEBAPP_NAME || !secrets.AZURE_CREDENTIALS }}
+        if: env.AZURE_WEBAPP_NAME == '' || env.AZURE_CREDENTIALS == ''
         run: |
           echo "AZURE_WEBAPP_NAME or AZURE_CREDENTIALS not set. Skipping deploy steps."
 
       - name: Deployment placeholder (secrets present)
-        if: ${{ secrets.AZURE_WEBAPP_NAME && secrets.AZURE_CREDENTIALS }}
+        if: env.AZURE_WEBAPP_NAME != '' && env.AZURE_CREDENTIALS != ''
         run: |
           echo "AZURE secrets present. Deployment steps intentionally omitted in this test workflow."


### PR DESCRIPTION
## Problem

Both `swa-test.yml` and `staged-deploy.yml` were failing with **"This run likely failed because of a workflow file issue"** on every push (0 jobs started, workflow name shown as file path instead of the `name:` field). They've been broken since introduction.

Root cause found via `actionlint`:

- **`swa-test.yml`**: `secrets` context is not allowed in step `if:` conditions (lines 42, 47)
- **`staged-deploy.yml`**: `env` context is not allowed in job-level `if:` conditions — only `github`, `inputs`, `needs`, `vars` are available there

## Fix

### `swa-test.yml`
Add job-level `env:` vars populated from the secrets, then reference `env.X` in step conditions:
```yaml
env:
  AZURE_WEBAPP_NAME: ${{ secrets.AZURE_WEBAPP_NAME }}
  AZURE_CREDENTIALS: ${{ secrets.AZURE_CREDENTIALS }}
```

### `staged-deploy.yml`
Add a `check-creds` job that outputs `has_creds=true/false`, then replace all `env.AZURE_CREDENTIALS != ''` job conditions with `needs.check-creds.outputs.has_creds == 'true'`.

Both files now pass `actionlint` with no errors.