### PR TITLE
feat: redesign frontend with CSS custom properties design system

### DIFF
--- a/src/frontend/src/App.css
+++ b/src/frontend/src/App.css
@@ -1,309 +1,576 @@
-* {
+/* ===================================================
+   DESIGN TOKENS
+   =================================================== */
+:root {
+  /* Surfaces */
+  --c-bg: #f0f4f8;
+  --c-surface: #ffffff;
+  --c-surface-2: #f8fafc;
+  --c-border: #e2e8f0;
+  --c-border-strong: #cbd5e1;
+
+  /* Text */
+  --c-text: #0f172a;
+  --c-text-2: #475569;
+  --c-text-3: #94a3b8;
+
+  /* Primary / Brand */
+  --c-primary: #2563eb;
+  --c-primary-dark: #1d4ed8;
+  --c-primary-tint: #eff6ff;
+  --c-primary-border: #bfdbfe;
+
+  /* Success / Verified / Node */
+  --c-green: #16a34a;
+  --c-green-tint: #f0fdf4;
+  --c-green-border: #86efac;
+
+  /* Danger / Archived / Composite */
+  --c-red: #dc2626;
+  --c-red-dark: #b91c1c;
+  --c-red-tint: #fef2f2;
+  --c-red-border: #fca5a5;
+
+  /* Warning / Stale */
+  --c-amber: #d97706;
+  --c-amber-tint: #fffbeb;
+  --c-amber-border: #fcd34d;
+
+  /* Docker */
+  --c-sky: #0369a1;
+  --c-sky-tint: #f0f9ff;
+  --c-sky-border: #7dd3fc;
+
+  /* Header */
+  --c-header: #0f172a;
+  --c-header-text: #f8fafc;
+  --c-header-sub: #94a3b8;
+
+  /* Tokens */
+  --r-sm: 6px;
+  --r-md: 10px;
+  --r-lg: 14px;
+  --r-pill: 9999px;
+
+  --shadow-sm: 0 1px 3px rgba(0, 0, 0, 0.07), 0 1px 2px rgba(0, 0, 0, 0.04);
+  --shadow-md: 0 4px 8px -2px rgba(0, 0, 0, 0.08), 0 2px 4px -1px rgba(0, 0, 0, 0.04);
+  --shadow-card-hover: 0 8px 20px -4px rgba(37, 99, 235, 0.18), 0 2px 8px -2px rgba(37, 99, 235, 0.08);
+
+  --t: 180ms ease;
+  --font-mono: 'SFMono-Regular', Consolas, 'Liberation Mono', Menlo, monospace;
+}
+
+@media (prefers-color-scheme: dark) {
+  :root {
+    --c-bg: #080d17;
+    --c-surface: #0f172a;
+    --c-surface-2: #1e293b;
+    --c-border: #1e293b;
+    --c-border-strong: #334155;
+
+    --c-text: #f1f5f9;
+    --c-text-2: #cbd5e1;
+    --c-text-3: #94a3b8;
+
+    --c-primary: #3b82f6;
+    --c-primary-dark: #2563eb;
+    --c-primary-tint: #172554;
+    --c-primary-border: #1e3a8a;
+
+    --c-green: #22c55e;
+    --c-green-tint: #052e16;
+    --c-green-border: #166534;
+
+    --c-red: #f87171;
+    --c-red-dark: #ef4444;
+    --c-red-tint: #2d0707;
+    --c-red-border: #7f1d1d;
+
+    --c-amber: #fbbf24;
+    --c-amber-tint: #1c0d00;
+    --c-amber-border: #78350f;
+
+    --c-sky: #38bdf8;
+    --c-sky-tint: #082f49;
+    --c-sky-border: #0c4a6e;
+
+    --c-header: #020617;
+    --c-header-text: #f1f5f9;
+    --c-header-sub: #94a3b8;
+
+    --shadow-sm: 0 1px 3px rgba(0, 0, 0, 0.4);
+    --shadow-md: 0 4px 8px -2px rgba(0, 0, 0, 0.5);
+    --shadow-card-hover: 0 8px 20px -4px rgba(59, 130, 246, 0.3), 0 2px 8px -2px rgba(59, 130, 246, 0.2);
+  }
+}
+
+/* ===================================================
+   BASE
+   =================================================== */
+*, *::before, *::after {
   box-sizing: border-box;
   margin: 0;
   padding: 0;
 }
 
 body {
-  font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Roboto', 'Oxygen',
-    'Ubuntu', 'Cantarell', 'Fira Sans', 'Droid Sans', 'Helvetica Neue',
-    sans-serif;
+  font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Roboto', 'Helvetica Neue', Arial, sans-serif;
+  font-size: 15px;
+  line-height: 1.6;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
-  background-color: #f5f5f5;
-  color: #333;
+  background: var(--c-bg);
+  color: var(--c-text);
 }
 
 #root {
   min-height: 100vh;
 }
 
+/* ===================================================
+   LAYOUT
+   =================================================== */
 .app {
   max-width: 1400px;
   margin: 0 auto;
-  padding: 20px;
+  padding: 0 20px 48px;
 }
 
+/* ===================================================
+   HEADER
+   =================================================== */
 .header {
-  background-color: #24292e;
-  color: white;
-  padding: 20px;
-  margin: -20px -20px 20px -20px;
-  box-shadow: 0 2px 4px rgba(0,0,0,0.1);
+  background: var(--c-header);
+  color: var(--c-header-text);
+  padding: 28px 20px 24px;
+  margin: 0 -20px 28px;
+  position: relative;
+  overflow: hidden;
+}
+
+.header::before {
+  content: '';
+  position: absolute;
+  inset: 0;
+  background:
+    radial-gradient(ellipse 65% 90% at 85% -10%, rgba(37, 99, 235, 0.3) 0%, transparent 65%),
+    radial-gradient(ellipse 45% 70% at 10% 110%, rgba(99, 102, 241, 0.2) 0%, transparent 65%);
+  pointer-events: none;
 }
 
 .header h1 {
-  font-size: 28px;
-  font-weight: 600;
+  font-size: 26px;
+  font-weight: 700;
+  letter-spacing: -0.4px;
+  position: relative;
 }
 
 .header p {
-  margin-top: 8px;
-  opacity: 0.8;
+  margin-top: 6px;
+  color: var(--c-header-sub);
+  font-size: 14px;
+  position: relative;
 }
 
+/* ===================================================
+   STATS BAR
+   =================================================== */
 .stats-bar {
   display: flex;
-  gap: 30px;
-  padding: 20px;
-  background: white;
-  border-radius: 8px;
+  gap: 2px;
+  background: var(--c-border);
+  border: 1.5px solid var(--c-border);
+  border-radius: var(--r-md);
   margin-bottom: 20px;
-  box-shadow: 0 1px 3px rgba(0,0,0,0.1);
+  overflow: hidden;
+  overflow-x: auto;
+  box-shadow: var(--shadow-sm);
+  scrollbar-width: none;
+}
+
+.stats-bar::-webkit-scrollbar {
+  display: none;
 }
 
 .stat-item {
   display: flex;
   flex-direction: column;
+  flex: 1;
 }
 
 .stat-button {
   border: 0;
-  background: transparent;
-  padding: 0;
+  background: var(--c-surface);
+  padding: 16px 20px;
   text-align: left;
   cursor: pointer;
+  transition: background var(--t);
+  min-width: 110px;
+  white-space: nowrap;
+  width: 100%;
+}
+
+.stat-button:hover {
+  background: var(--c-primary-tint);
 }
 
 .stat-button:hover .stat-label {
-  color: #24292e;
-}
-
-.stat-button:hover .stat-value {
-  text-decoration: underline;
+  color: var(--c-primary);
 }
 
 .stat-button:focus-visible {
-  outline: 2px solid #0366d6;
-  outline-offset: 4px;
-  border-radius: 4px;
+  outline: 2px solid var(--c-primary);
+  outline-offset: -2px;
+  position: relative;
+  z-index: 1;
 }
 
 .stat-label {
-  font-size: 14px;
-  color: #666;
-  margin-bottom: 4px;
+  font-size: 11px;
+  font-weight: 600;
+  color: var(--c-text-3);
+  margin-bottom: 5px;
+  text-transform: uppercase;
+  letter-spacing: 0.6px;
 }
 
 .stat-value {
-  font-size: 24px;
-  font-weight: 600;
-  color: #0366d6;
+  font-size: 22px;
+  font-weight: 700;
+  color: var(--c-primary);
+  line-height: 1;
 }
 
+/* ===================================================
+   CONTROLS
+   =================================================== */
 .controls {
   display: flex;
-  gap: 12px;
+  gap: 10px;
   margin-bottom: 20px;
   flex-wrap: wrap;
-  align-items: center;
+  align-items: flex-start;
 }
 
 .controls-row {
   display: flex;
-  gap: 12px;
-  margin-bottom: 20px;
+  gap: 10px;
   flex-wrap: wrap;
   align-items: center;
+  width: 100%;
 }
 
-/* Ensure controls-row spans full width under the search/type controls */
 .controls > .controls-row,
 .controls-row {
   width: 100%;
 }
 
 .search-box {
-  flex: 1 1 420px;
-  min-width: 240px;
+  flex: 1 1 380px;
+  min-width: 220px;
 }
 
 .search-box input {
   width: 100%;
-  padding: 12px 16px;
-  font-size: 16px;
-  border: 1px solid #d1d5da;
-  border-radius: 6px;
+  padding: 11px 16px;
+  font-size: 15px;
+  border: 1.5px solid var(--c-border-strong);
+  border-radius: var(--r-md);
+  background: var(--c-surface);
+  color: var(--c-text);
   outline: none;
+  transition: border-color var(--t), box-shadow var(--t);
+  box-shadow: var(--shadow-sm);
+}
+
+.search-box input::placeholder {
+  color: var(--c-text-3);
 }
 
 .search-box input:focus {
-  border-color: #0366d6;
-  box-shadow: 0 0 0 3px rgba(3, 102, 214, 0.1);
+  border-color: var(--c-primary);
+  box-shadow: 0 0 0 3px rgba(37, 99, 235, 0.12);
 }
 
 .filter-group {
   display: inline-flex;
-  gap: 8px;
   align-items: center;
-  background: white;
+  gap: 6px;
+  background: var(--c-surface);
   padding: 8px 12px;
-  border-radius: 6px;
-  border: 1px solid #d1d5da;
+  border-radius: var(--r-md);
+  border: 1.5px solid var(--c-border-strong);
+  box-shadow: var(--shadow-sm);
 }
 
 .filter-group label {
-  font-size: 14px;
-  font-weight: 600;
-  color: #666;
+  font-size: 12px;
+  font-weight: 700;
+  color: var(--c-text-2);
+  white-space: nowrap;
+  text-transform: uppercase;
+  letter-spacing: 0.4px;
 }
 
 .filter-group button {
-  padding: 8px 16px;
-  border: 1px solid #d1d5da;
-  background: white;
-  border-radius: 4px;
+  padding: 5px 13px;
+  border: 1.5px solid var(--c-border);
+  background: transparent;
+  border-radius: var(--r-pill);
   cursor: pointer;
-  font-size: 14px;
-  transition: all 0.2s;
+  font-size: 13px;
+  font-weight: 500;
+  color: var(--c-text-2);
+  transition: all var(--t);
+  white-space: nowrap;
 }
 
 .filter-group button:hover {
-  background: #f6f8fa;
+  border-color: var(--c-primary);
+  color: var(--c-primary);
+  background: var(--c-primary-tint);
 }
 
 .filter-group button.active {
-  background: #0366d6;
+  background: var(--c-primary);
   color: white;
-  border-color: #0366d6;
+  border-color: var(--c-primary);
 }
 
 .filter-group button.danger {
-  border-color: #d73a49;
-  color: #d73a49;
+  border-color: var(--c-red-border);
+  color: var(--c-red);
 }
 
 .filter-group button.danger:hover {
-  background: #fff5f0;
+  background: var(--c-red-tint);
 }
 
 .filter-group button.danger.active {
-  background: #d73a49;
-  border-color: #d73a49;
+  background: var(--c-red);
+  border-color: var(--c-red);
   color: white;
 }
 
-/* Styled select controls inside filter groups to match the rest of the UI */
 .filter-group select {
-  padding: 8px 36px 8px 12px;
-  font-size: 14px;
-  border: 1px solid #d1d5da;
-  border-radius: 6px;
-  background: white url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 20 20'><path fill='%23666' d='M5 7l5 5 5-5z'/></svg>") no-repeat right 10px center;
-  background-size: 12px;
+  padding: 6px 32px 6px 10px;
+  font-size: 13px;
+  font-weight: 500;
+  border: 1.5px solid var(--c-border);
+  border-radius: var(--r-sm);
+  background: var(--c-surface) url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 20 20'><path fill='%2394a3b8' d='M5 7l5 5 5-5z'/></svg>") no-repeat right 8px center;
+  background-size: 14px;
   cursor: pointer;
   -webkit-appearance: none;
   -moz-appearance: none;
   appearance: none;
-  min-width: 120px;
+  min-width: 130px;
+  color: var(--c-text);
+  transition: border-color var(--t), box-shadow var(--t);
 }
 
 .filter-group select:focus {
-  border-color: #0366d6;
-  box-shadow: 0 0 0 3px rgba(3,102,214,0.08);
+  border-color: var(--c-primary);
+  box-shadow: 0 0 0 3px rgba(37, 99, 235, 0.1);
   outline: none;
 }
 
-/* Align labels and selects nicely */
-.filter-group label {
-  margin-right: 6px;
-}
-
-/* Remove default IE dropdown arrow */
 .filter-group select::-ms-expand {
   display: none;
 }
 
+/* ===================================================
+   ACTIONS GRID
+   =================================================== */
 .actions-grid {
   display: grid;
-  grid-template-columns: repeat(auto-fill, minmax(350px, 1fr));
-  gap: 20px;
+  grid-template-columns: repeat(auto-fill, minmax(340px, 1fr));
+  gap: 16px;
+  margin-bottom: 20px;
 }
 
+/* ===================================================
+   ACTION CARD
+   =================================================== */
 .action-card {
-  background: white;
-  border: 1px solid #d1d5da;
-  border-radius: 8px;
-  padding: 20px;
+  background: var(--c-surface);
+  border: 1.5px solid var(--c-border);
+  border-radius: var(--r-lg);
+  padding: 0;
   cursor: pointer;
-  transition: all 0.2s;
-  box-shadow: 0 1px 3px rgba(0,0,0,0.05);
+  transition: border-color var(--t), box-shadow var(--t), transform var(--t);
+  box-shadow: var(--shadow-sm);
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+}
+
+/* Coloured top accent bar */
+.action-card::before {
+  content: '';
+  display: block;
+  height: 3px;
+  background: var(--c-border-strong);
+  transition: background var(--t);
+  flex-shrink: 0;
 }
 
 .action-card:hover {
-  border-color: #0366d6;
-  box-shadow: 0 4px 12px rgba(0,0,0,0.1);
+  border-color: var(--c-primary-border);
+  box-shadow: var(--shadow-card-hover);
   transform: translateY(-2px);
 }
 
+.action-card:hover::before {
+  background: var(--c-primary);
+}
+
+/* Node cards get green accent on hover */
+.action-card:has(.badge-node):hover::before {
+  background: var(--c-green);
+}
+
+/* Docker cards get sky accent on hover */
+.action-card:has(.badge-docker):hover::before {
+  background: var(--c-sky);
+}
+
+/* Composite cards get red accent */
+.action-card:has(.badge-composite)::before {
+  background: var(--c-red-border);
+}
+
+.action-card:has(.badge-composite):hover::before {
+  background: var(--c-red);
+}
+
 .action-card.archived {
-  border: 2px solid #d73a49;
-  background: #ffeef0;
+  border-color: var(--c-red-border);
+  background: var(--c-red-tint);
+}
+
+.action-card.archived::before {
+  background: var(--c-red);
 }
 
 .action-card.archived:hover {
-  border-color: #d73a49;
-  box-shadow: 0 4px 12px rgba(215, 58, 73, 0.3);
+  border-color: var(--c-red);
+  box-shadow: 0 8px 20px -4px rgba(220, 38, 38, 0.2);
+}
+
+/* Inner card content wrapper */
+.action-card > .action-header,
+.action-card > .action-meta {
+  padding: 0 18px;
+}
+
+.action-card > .action-header {
+  padding: 18px 18px 0;
+}
+
+.action-card > .action-meta:last-child {
+  padding-bottom: 14px;
 }
 
 .action-header {
   display: flex;
   align-items: flex-start;
   justify-content: space-between;
-  margin-bottom: 12px;
+  gap: 10px;
+  margin-bottom: 14px;
 }
 
 .action-title {
   flex: 1;
+  min-width: 0;
 }
 
 .action-owner {
-  font-size: 14px;
-  color: #586069;
-  margin-bottom: 4px;
+  font-size: 12px;
+  font-weight: 500;
+  color: var(--c-text-3);
+  margin-bottom: 2px;
+  letter-spacing: 0.2px;
 }
 
 .action-name {
-  font-size: 18px;
-  font-weight: 600;
-  color: #24292e;
+  font-size: 16px;
+  font-weight: 700;
+  color: var(--c-text);
   word-break: break-word;
+  line-height: 1.3;
 }
 
+/* ===================================================
+   BADGES
+   =================================================== */
 .action-badge {
-  padding: 4px 8px;
-  border-radius: 4px;
-  font-size: 12px;
-  font-weight: 600;
+  padding: 3px 10px;
+  border-radius: var(--r-pill);
+  font-size: 11px;
+  font-weight: 700;
   white-space: nowrap;
+  letter-spacing: 0.3px;
+  flex-shrink: 0;
+  border: 1.5px solid transparent;
 }
 
 .badge-node {
-  background: #f0fff4;
-  color: #22863a;
-  border: 1px solid #34d058;
+  background: var(--c-green-tint);
+  color: var(--c-green);
+  border-color: var(--c-green-border);
 }
 
 .badge-docker {
-  background: #f0f6ff;
-  color: #0366d6;
-  border: 1px solid #0366d6;
+  background: var(--c-sky-tint);
+  color: var(--c-sky);
+  border-color: var(--c-sky-border);
 }
 
 .badge-composite {
-  background: #fff5f0;
-  color: #d73a49;
-  border: 1px solid #d73a49;
+  background: var(--c-red-tint);
+  color: var(--c-red);
+  border-color: var(--c-red-border);
 }
 
+.verified-badge {
+  background: var(--c-green-tint);
+  color: var(--c-green);
+  padding: 3px 10px;
+  border-radius: var(--r-pill);
+  font-size: 11px;
+  font-weight: 700;
+  border: 1.5px solid var(--c-green-border);
+}
+
+.archived-badge {
+  background: var(--c-red-tint);
+  color: var(--c-red);
+  padding: 3px 10px;
+  border-radius: var(--r-pill);
+  font-size: 11px;
+  font-weight: 700;
+  border: 1.5px solid var(--c-red-border);
+}
+
+/* ===================================================
+   CARD META
+   =================================================== */
 .action-meta {
   display: flex;
-  gap: 16px;
-  margin-top: 12px;
+  gap: 12px;
+  flex-wrap: wrap;
   padding-top: 12px;
-  border-top: 1px solid #e1e4e8;
-  font-size: 14px;
-  color: #586069;
+  border-top: 1px solid var(--c-border);
+  font-size: 13px;
+  color: var(--c-text-2);
+  margin-top: auto;
+}
+
+.action-meta + .action-meta {
+  border-top: none;
+  padding-top: 4px;
+  margin-top: 0;
 }
 
 .meta-item {
@@ -313,50 +580,58 @@ body {
 }
 
 .meta-item strong {
-  color: #24292e;
+  color: var(--c-text);
 }
 
 .dependents-highlight {
-  color: #0366d6;
-  font-weight: 600;
-  font-size: 16px;
+  color: var(--c-primary);
+  font-weight: 700;
+  font-size: 15px;
 }
 
+/* ===================================================
+   LOADING / STATES
+   =================================================== */
 .loading {
   text-align: center;
   padding: 60px 20px;
-  font-size: 18px;
-  color: #586069;
+  font-size: 16px;
+  color: var(--c-text-2);
 }
 
 .no-results {
   text-align: center;
   padding: 60px 20px;
-  color: #586069;
+  color: var(--c-text-2);
 }
 
 .no-results h2 {
-  font-size: 24px;
+  font-size: 22px;
+  font-weight: 700;
   margin-bottom: 8px;
+  color: var(--c-text);
 }
 
+/* ===================================================
+   PAGINATION
+   =================================================== */
 .pagination {
   display: flex;
   justify-content: space-between;
   align-items: center;
   gap: 12px;
-  margin: 20px 0;
   padding: 12px 16px;
-  background: white;
-  border: 1px solid #d1d5da;
-  border-radius: 6px;
-  box-shadow: 0 1px 3px rgba(0,0,0,0.05);
+  background: var(--c-surface);
+  border: 1.5px solid var(--c-border);
+  border-radius: var(--r-md);
+  box-shadow: var(--shadow-sm);
   flex-wrap: wrap;
 }
 
 .pagination-summary {
-  font-size: 14px;
-  color: #586069;
+  font-size: 13px;
+  color: var(--c-text-2);
+  font-weight: 500;
 }
 
 .pagination-controls {
@@ -366,72 +641,89 @@ body {
 }
 
 .pagination-controls button {
-  padding: 8px 12px;
-  border: 1px solid #d1d5da;
-  background: white;
-  border-radius: 4px;
+  padding: 7px 16px;
+  border: 1.5px solid var(--c-border-strong);
+  background: var(--c-surface);
+  border-radius: var(--r-sm);
   cursor: pointer;
-  font-size: 14px;
-  transition: all 0.2s;
+  font-size: 13px;
+  font-weight: 500;
+  color: var(--c-text);
+  transition: all var(--t);
 }
 
 .pagination-controls button:hover:not(:disabled) {
-  background: #f6f8fa;
+  border-color: var(--c-primary);
+  color: var(--c-primary);
+  background: var(--c-primary-tint);
 }
 
 .pagination-controls button:disabled {
   cursor: not-allowed;
-  opacity: 0.6;
+  opacity: 0.4;
 }
 
 .pagination-page {
-  font-size: 14px;
-  color: #24292e;
+  font-size: 13px;
+  font-weight: 500;
+  color: var(--c-text-2);
+  padding: 0 4px;
 }
 
+/* ===================================================
+   DETAIL PAGE
+   =================================================== */
 .detail-page {
-  background: white;
-  border-radius: 8px;
-  padding: 30px;
-  box-shadow: 0 1px 3px rgba(0,0,0,0.1);
+  background: var(--c-surface);
+  border-radius: var(--r-lg);
+  padding: 32px;
+  box-shadow: var(--shadow-md);
+  border: 1.5px solid var(--c-border);
 }
 
 .back-button {
   display: inline-flex;
   align-items: center;
-  gap: 8px;
-  padding: 8px 16px;
+  gap: 6px;
+  padding: 8px 14px;
   margin-bottom: 20px;
-  background: #f6f8fa;
-  border: 1px solid #d1d5da;
-  border-radius: 6px;
+  background: var(--c-surface);
+  border: 1.5px solid var(--c-border-strong);
+  border-radius: var(--r-md);
   cursor: pointer;
-  font-size: 14px;
+  font-size: 13px;
+  font-weight: 500;
   text-decoration: none;
-  color: #24292e;
-  transition: all 0.2s;
+  color: var(--c-text-2);
+  transition: all var(--t);
+  box-shadow: var(--shadow-sm);
 }
 
 .back-button:hover {
-  background: #e1e4e8;
+  border-color: var(--c-primary);
+  color: var(--c-primary);
+  background: var(--c-primary-tint);
 }
 
 .detail-header {
-  margin-bottom: 30px;
+  margin-bottom: 28px;
   padding-bottom: 20px;
-  border-bottom: 2px solid #e1e4e8;
+  border-bottom: 1.5px solid var(--c-border);
 }
 
 .detail-title {
-  font-size: 32px;
-  font-weight: 600;
-  margin-bottom: 8px;
+  font-size: 28px;
+  font-weight: 800;
+  letter-spacing: -0.5px;
+  margin-bottom: 10px;
+  color: var(--c-text);
+  line-height: 1.2;
 }
 
 .detail-owner {
-  font-size: 18px;
-  color: #586069;
-  margin-bottom: 16px;
+  font-size: 16px;
+  color: var(--c-text-2);
+  margin-bottom: 14px;
 }
 
 .detail-badges {
@@ -440,98 +732,123 @@ body {
   flex-wrap: wrap;
 }
 
+/* ===================================================
+   INFO GRID (detail page)
+   =================================================== */
 .info-grid {
   display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(250px, 1fr));
-  gap: 20px;
-  margin-bottom: 30px;
+  grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+  gap: 16px;
+  margin-bottom: 24px;
 }
 
 .info-card {
-  padding: 16px;
-  background: #f6f8fa;
-  border-radius: 6px;
-  border: 1px solid #e1e4e8;
+  padding: 18px 20px;
+  background: var(--c-surface-2);
+  border-radius: var(--r-md);
+  border: 1.5px solid var(--c-border);
 }
 
 .info-card.archived {
-  border: 2px solid #d73a49;
-  background: #ffeef0;
+  border-color: var(--c-red-border);
+  background: var(--c-red-tint);
+}
+
+.info-card.aged {
+  border-color: var(--c-amber-border);
+  background: var(--c-amber-tint);
+}
+
+.info-card.stale {
+  border-color: var(--c-red-border);
+  background: var(--c-red-tint);
 }
 
 .info-card h3 {
-  font-size: 14px;
-  color: #586069;
+  font-size: 11px;
+  font-weight: 700;
+  color: var(--c-text-3);
   margin-bottom: 8px;
   text-transform: uppercase;
-  letter-spacing: 0.5px;
+  letter-spacing: 0.8px;
 }
 
 .info-card .value {
   font-size: 20px;
-  font-weight: 600;
-  color: #24292e;
+  font-weight: 700;
+  color: var(--c-text);
 }
 
-/* Age indicators for Last Updated */
 .info-card .value.aged {
-  color: #d9822b; /* orange-ish */
+  color: var(--c-amber);
 }
 
 .info-card .value.stale {
-  color: #d73a49; /* red */
+  color: var(--c-red);
 }
 
-/* Make the whole info-card panel stand out when aged/stale */
-.info-card.aged {
-  border-color: #d9822b;
-  background: rgba(217,130,43,0.06);
-}
-
-.info-card.stale {
-  border-color: #d73a49;
-  background: rgba(215,58,73,0.06);
-}
-
+/* ===================================================
+   VERSION SELECTOR
+   =================================================== */
 .version-selector {
-  margin-bottom: 30px;
+  margin-bottom: 28px;
 }
 
 .version-selector label {
   display: block;
-  font-size: 14px;
+  font-size: 13px;
   font-weight: 600;
   margin-bottom: 8px;
-  color: #24292e;
+  color: var(--c-text);
 }
 
 .version-selector select {
-  padding: 10px 12px;
-  font-size: 16px;
-  border: 1px solid #d1d5da;
-  border-radius: 6px;
-  background: white;
+  padding: 10px 36px 10px 14px;
+  font-size: 14px;
+  border: 1.5px solid var(--c-border-strong);
+  border-radius: var(--r-md);
+  background: var(--c-surface) url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 20 20'><path fill='%2394a3b8' d='M5 7l5 5 5-5z'/></svg>") no-repeat right 10px center;
+  background-size: 14px;
   cursor: pointer;
   min-width: 200px;
+  color: var(--c-text);
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+  transition: border-color var(--t);
 }
 
+.version-selector select:focus {
+  border-color: var(--c-primary);
+  box-shadow: 0 0 0 3px rgba(37, 99, 235, 0.12);
+  outline: none;
+}
+
+/* ===================================================
+   README
+   =================================================== */
 .readme-section {
-  margin-top: 30px;
+  margin-top: 28px;
 }
 
 .readme-section h2 {
-  font-size: 24px;
+  font-size: 20px;
+  font-weight: 700;
   margin-bottom: 16px;
+  color: var(--c-text);
 }
 
 .readme-content {
   width: 100%;
   min-height: 200px;
-  padding: 20px;
-  border: 1px solid #d1d5da;
-  border-radius: 6px;
-  background: white;
+  padding: 24px;
+  border: 1.5px solid var(--c-border);
+  border-radius: var(--r-md);
+  background: var(--c-surface);
   overflow-x: auto;
+  font-size: 15px;
+  line-height: 1.7;
+  color: var(--c-text);
 }
 
 .readme-content img {
@@ -540,23 +857,27 @@ body {
 }
 
 .readme-content pre {
-  background-color: #f6f8fa;
-  padding: 16px;
-  border-radius: 6px;
+  background: var(--c-surface-2);
+  padding: 16px 20px;
+  border-radius: var(--r-sm);
   overflow-x: auto;
+  border: 1px solid var(--c-border);
+  margin: 16px 0;
 }
 
 .readme-content code {
-  background-color: #f6f8fa;
+  background: var(--c-surface-2);
   padding: 2px 6px;
-  border-radius: 3px;
-  font-family: 'SFMono-Regular', Consolas, 'Liberation Mono', Menlo, monospace;
-  font-size: 85%;
+  border-radius: 4px;
+  font-family: var(--font-mono);
+  font-size: 13px;
+  border: 1px solid var(--c-border);
 }
 
 .readme-content pre code {
   padding: 0;
-  background-color: transparent;
+  background: transparent;
+  border: none;
 }
 
 .readme-content table {
@@ -567,24 +888,28 @@ body {
 
 .readme-content table th,
 .readme-content table td {
-  border: 1px solid #d1d5da;
-  padding: 8px 12px;
+  border: 1px solid var(--c-border);
+  padding: 10px 14px;
+  text-align: left;
 }
 
 .readme-content table th {
-  background-color: #f6f8fa;
+  background: var(--c-surface-2);
   font-weight: 600;
+  font-size: 13px;
 }
 
 .readme-content blockquote {
-  margin: 0;
-  padding-left: 16px;
-  border-left: 4px solid #d1d5da;
-  color: #6a737d;
+  margin: 16px 0;
+  padding: 12px 16px;
+  border-left: 4px solid var(--c-primary);
+  background: var(--c-primary-tint);
+  border-radius: 0 var(--r-sm) var(--r-sm) 0;
+  color: var(--c-text-2);
 }
 
 .readme-content a {
-  color: #0366d6;
+  color: var(--c-primary);
   text-decoration: none;
 }
 
@@ -592,39 +917,96 @@ body {
   text-decoration: underline;
 }
 
+.readme-content h1,
+.readme-content h2,
+.readme-content h3,
+.readme-content h4,
+.readme-content h5,
+.readme-content h6 {
+  margin: 24px 0 12px;
+  color: var(--c-text);
+  font-weight: 700;
+  line-height: 1.3;
+}
+
+.readme-content h1 {
+  font-size: 24px;
+  border-bottom: 1px solid var(--c-border);
+  padding-bottom: 8px;
+}
+
+.readme-content h2 {
+  font-size: 20px;
+  border-bottom: 1px solid var(--c-border);
+  padding-bottom: 6px;
+}
+
+.readme-content h3 { font-size: 17px; }
+
+.readme-content ul,
+.readme-content ol {
+  padding-left: 24px;
+  margin: 12px 0;
+}
+
+.readme-content p {
+  margin: 12px 0;
+}
+
+/* ===================================================
+   ERROR
+   =================================================== */
 .error-message {
-  padding: 20px;
-  background: #ffeef0;
-  border: 1px solid #d73a49;
-  border-radius: 6px;
-  color: #d73a49;
+  padding: 16px 20px;
+  background: var(--c-red-tint);
+  border: 1.5px solid var(--c-red-border);
+  border-radius: var(--r-md);
+  color: var(--c-red);
   margin: 20px 0;
+  font-weight: 500;
 }
 
-.verified-badge {
-  background: #dcffe4;
-  color: #22863a;
-  padding: 4px 8px;
-  border-radius: 4px;
-  font-size: 12px;
+/* ===================================================
+   REPO LINK
+   =================================================== */
+.repo-link {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  margin-top: 10px;
+  padding: 7px 14px;
+  background: var(--c-primary);
+  color: white;
+  text-decoration: none;
+  border-radius: var(--r-md);
+  font-size: 13px;
   font-weight: 600;
-  border: 1px solid #34d058;
+  transition: all var(--t);
+  border: 1.5px solid var(--c-primary);
 }
 
-.archived-badge {
-  background: #ffeef0;
-  color: #d73a49;
-  padding: 4px 8px;
-  border-radius: 4px;
-  font-size: 12px;
-  font-weight: 600;
-  border: 1px solid #d73a49;
+.repo-link:hover {
+  background: var(--c-primary-dark);
+  border-color: var(--c-primary-dark);
+  transform: translateY(-1px);
+  box-shadow: 0 4px 12px rgba(37, 99, 235, 0.3);
 }
 
+.repo-link:active {
+  transform: translateY(0);
+}
+
+/* ===================================================
+   RESPONSIVE
+   =================================================== */
 @media (max-width: 768px) {
-  .stats-bar {
-    flex-direction: column;
-    gap: 15px;
+  .stat-button {
+    padding: 14px 14px;
+    min-width: 90px;
+  }
+
+  .stat-value {
+    font-size: 18px;
   }
 
   .controls {
@@ -640,33 +1022,20 @@ body {
   }
 
   .info-grid {
-    grid-template-columns: 1fr;
+    grid-template-columns: 1fr 1fr;
+  }
+
+  .detail-page {
+    padding: 20px 16px;
   }
 }
 
-.repo-link {
-  display: inline-flex;
-  align-items: center;
-  gap: 4px;
-  margin-top: 8px;
-  padding: 6px 12px;
-  background: #0366d6;
-  color: white;
-  text-decoration: none;
-  border-radius: 4px;
-  font-size: 13px;
-  font-weight: 600;
-  transition: all 0.2s;
-  border: 1px solid #0366d6;
-}
+@media (max-width: 480px) {
+  .info-grid {
+    grid-template-columns: 1fr;
+  }
 
-.repo-link:hover {
-  background: #0256c5;
-  border-color: #0256c5;
-  transform: translateY(-1px);
-  box-shadow: 0 2px 6px rgba(3, 102, 214, 0.3);
-}
-
-.repo-link:active {
-  transform: translateY(0);
+  .detail-title {
+    font-size: 22px;
+  }
 }


### PR DESCRIPTION
## Summary

- Replace 673-line flat stylesheet of hardcoded hex colors with a full token-based design system using CSS custom properties
- Add automatic dark mode via `@media (prefers-color-scheme: dark)` — zero JS required
- Improve visual hierarchy across header, stats bar, filter controls, and action cards

## What changed

**Design tokens (`App.css`)**
- All colors, radii, shadows and transitions are now CSS custom properties in `:root`, making any future theme change a one-line edit
- Complete dark palette defined in a single `@media (prefers-color-scheme: dark)` block

**Header**
- Dark navy background with radial gradient highlights for visual depth

**Stats bar**
- 7 clickable metric tiles (Total, Verified, Node, Docker, Composite, Unknown, Archived) with large numeric values and styled labels

**Action cards**
- 3px top accent bar per card; color shifts on hover based on action type (Node=green, Docker=sky, Composite=red) using CSS `:has()`
- Structured metadata rows for dependents count, verified badge, OpenSSF score, latest release, and last updated date

**Text contrast fix**
- Dark-mode secondary/tertiary text tokens (`--c-text-2`, `--c-text-3`, `--c-header-sub`) were bumped from near-invisible slate-600/400 values to slate-300/400 for WCAG-compliant contrast

## Reviewer notes

- No JavaScript changes — purely CSS
- Light mode is fully supported; dark mode activates automatically via OS preference
- `.env.local` was modified locally during development to point at a mock API server for screenshots but is gitignored and not included in this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)