### PR TITLE
fix: decode action name before calling GitHub readme API

### DIFF
--- a/src/backend/ActionsReadme/index.js
+++ b/src/backend/ActionsReadme/index.js
@@ -3,10 +3,12 @@ const { getGitHubAuthHeaders } = require('../lib/githubAuth');
 const { getCachedReadme, cacheReadme, isCacheValid } = require('../lib/readmeCache');
 const { getActionEntity } = require('../lib/tableStorage');
 const { ActionRecord } = require('../lib/actionRecord');
+const { extractRepoName } = require('../lib/actionNameDecoder');
 
 async function fetchReadmeFromGitHub(owner, name, version) {
   const ref = version || 'main';
-  const url = `https://api.github.com/repos/${owner}/${name}/readme?ref=${ref}`;
+  const repoName = extractRepoName(owner, name);
+  const url = `https://api.github.com/repos/${owner}/${repoName}/readme?ref=${ref}`;
   
   const headers = await getGitHubAuthHeaders();
 

--- a/src/backend/lib/actionNameDecoder.js
+++ b/src/backend/lib/actionNameDecoder.js
@@ -1,0 +1,29 @@
+/**
+ * Extracts the GitHub repository name from the combined action name.
+ *
+ * The data pipeline (GetForkedRepoName in library.ps1) encodes action names as
+ * `{owner}_{repoName}` where any slashes in composite action paths are replaced
+ * with underscores. For example:
+ *   - actions/setup-java        → "actions_setup-java"
+ *   - github/codeql-action/analyze → "github_codeql-action_analyze"
+ *
+ * GitHub org names cannot contain underscores, so the first underscore always
+ * separates the owner from the rest of the path. For composite actions, only the
+ * repository name (first path segment) is returned since the GitHub repos API
+ * (`/repos/{owner}/{repo}/readme`) expects just the repository name.
+ *
+ * @param {string} owner - GitHub organization or user name
+ * @param {string} name  - Combined action name in {owner}_{repo} format
+ * @returns {string} The GitHub repository name
+ */
+function extractRepoName(owner, name) {
+  const prefix = owner + '_';
+  if (!name.startsWith(prefix)) {
+    return name; // fallback: use name as-is
+  }
+  // Strip owner prefix, restore slash encoding, take only the repo name (first segment)
+  const repoPath = name.substring(prefix.length).replace(/_/g, '/');
+  return repoPath.split('/')[0];
+}
+
+module.exports = { extractRepoName };

--- a/src/backend/tests/actionsReadme.test.js
+++ b/src/backend/tests/actionsReadme.test.js
@@ -1,0 +1,31 @@
+const { extractRepoName } = require('../lib/actionNameDecoder');
+
+describe('actionsReadme', () => {
+  describe('extractRepoName', () => {
+    it('should strip the owner prefix from a simple repo name', () => {
+      expect(extractRepoName('actions', 'actions_setup-java')).toBe('setup-java');
+    });
+
+    it('should handle repos with hyphens', () => {
+      expect(extractRepoName('actions', 'actions_checkout')).toBe('checkout');
+    });
+
+    it('should return only the repo name for composite action paths', () => {
+      // github/codeql-action/analyze → stored as github_codeql-action_analyze
+      expect(extractRepoName('github', 'github_codeql-action_analyze')).toBe('codeql-action');
+    });
+
+    it('should return only the repo name for deep composite paths', () => {
+      // org/repo/.github/actions/my-action → org_repo_.github_actions_my-action
+      expect(extractRepoName('org', 'org_repo_.github_actions_my-action')).toBe('repo');
+    });
+
+    it('should fall back to name as-is when no owner prefix found', () => {
+      expect(extractRepoName('actions', 'no-prefix-here')).toBe('no-prefix-here');
+    });
+
+    it('should handle case where owner appears at start but no underscore', () => {
+      expect(extractRepoName('myorg', 'myorg')).toBe('myorg');
+    });
+  });
+});


### PR DESCRIPTION
All README requests fail because the name field (e.g. actions_setup-java) was passed directly to the GitHub API instead of the repo name (setup-java). Added extractRepoName() lib and tests.