### PR TITLE
fix: handle 999+ dependents string -- preserve suffix in display and sort

### DIFF
--- a/src/frontend/src/pages/DetailPage.tsx
+++ b/src/frontend/src/pages/DetailPage.tsx
@@ -2,7 +2,7 @@ import React, { useEffect, useState } from 'react';
 import { useParams, useNavigate } from 'react-router-dom';
 import DOMPurify from 'dompurify';
 import { Action } from '../types/Action';
-import { actionsService } from '../services/actionsService';
+import { actionsService, formatDependentsCount } from '../services/actionsService';
 import { splitOwnerRepo } from '../services/utils';
 
 export const DetailPage: React.FC = () => {
@@ -138,7 +138,7 @@ export const DetailPage: React.FC = () => {
     );
   }
 
-  const dependentsCount = parseInt(action.dependents.dependents);
+  const dependentsDisplay = formatDependentsCount(action.dependents.dependents);
 
   return (
     <div className="app">
@@ -177,7 +177,7 @@ export const DetailPage: React.FC = () => {
           <div className={`info-card ${action.repoInfo.archived ? 'archived' : ''}`}>
             <h3>Used by</h3>
             <div className="value dependents-highlight">
-              {dependentsCount.toLocaleString()}
+              {dependentsDisplay}
             </div>
           </div>
 

--- a/src/frontend/src/pages/OverviewPage.tsx
+++ b/src/frontend/src/pages/OverviewPage.tsx
@@ -1,7 +1,7 @@
 import React, { useEffect, useRef, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { Action, ActionStats, ActionTypeFilter } from '../types/Action';
-import { actionsService } from '../services/actionsService';
+import { actionsService, parseDependentsCount, formatDependentsCount } from '../services/actionsService';
 import { normalizeRepoName, matchesSearchQuery, isActionVerified } from '../services/utils';
 import { AnimatedCounter } from '../components/AnimatedCounter';
 
@@ -238,8 +238,8 @@ export const OverviewPage: React.FC = () => {
     // Apply sorting
     filtered = [...filtered].sort((a, b) => {
       if (sortBy === 'dependents') {
-        const aDeps = parseInt(a?.dependents?.dependents || '') || 0;
-        const bDeps = parseInt(b?.dependents?.dependents || '') || 0;
+        const aDeps = parseDependentsCount(a?.dependents?.dependents);
+        const bDeps = parseDependentsCount(b?.dependents?.dependents);
         return bDeps - aDeps; // Descending
       } else {
         // Sort by updated date
@@ -558,7 +558,7 @@ export const OverviewPage: React.FC = () => {
                   <div className="meta-item">
                     <span>👥</span>
                     <strong className="dependents-highlight">
-                      {(parseInt(action?.dependents?.dependents || '') || 0).toLocaleString()}
+                      {formatDependentsCount(action?.dependents?.dependents)}
                     </strong>
                     <span>Used by</span>
                   </div>

--- a/src/frontend/src/services/actionsService.ts
+++ b/src/frontend/src/services/actionsService.ts
@@ -33,6 +33,26 @@ function getApiBaseUrl(): string {
 
 const API_BASE_URL = getApiBaseUrl();
 
+// Parses a dependents count string that may end with "+" (e.g. "999+").
+// Returns a numeric value suitable for sorting; "999+" sorts above "999".
+export function parseDependentsCount(value: string | undefined): number {
+  if (!value) return 0;
+  const isPlus = value.endsWith('+');
+  const num = parseInt(value, 10);
+  if (!Number.isFinite(num)) return 0;
+  // Fractional bump ensures "999+" sorts strictly above "999".
+  return isPlus ? num + 0.5 : num;
+}
+
+// Formats a dependents count string for display, preserving any "+" suffix.
+export function formatDependentsCount(value: string | undefined): string {
+  if (!value) return '0';
+  const isPlus = value.endsWith('+');
+  const num = parseInt(value, 10);
+  if (!Number.isFinite(num)) return '0';
+  return isPlus ? `${num.toLocaleString()}+` : num.toLocaleString();
+}
+
 function normalizeStringArray(value: unknown): string[] {
   if (!Array.isArray(value)) {
     return [];


### PR DESCRIPTION
## Problem

In production the "Used by" count shows at most 999, even for very popular actions. Root cause: the data source stores the dependents count as a string ending with "+" (e.g. "999+") when GitHub's UI caps the display value. parseInt("999+") silently truncates at the "+" and returns 999, so:

- The card shows 999 instead of 999+
- Sorting by "Used by" treats all capped actions as equal

## Fix (this repo)

Two exported helpers added to actionsService.ts:

- formatDependentsCount(value): Preserves the + suffix -- "999+" displays as "999+"
- parseDependentsCount(value): Numeric sort value -- "999+" returns 999.5 (sorts above exact 999)

Both OverviewPage (card display + sort comparator) and DetailPage ("Used by" card) are updated to use these helpers.

## Source data note

This repo now handles the "999+" format gracefully, but the actual dependent counts are lost at the source -- the data collection pipeline stores whatever GitHub's UI renders rather than querying the real number. If you want exact counts above 999, the scraper needs to be updated to use the GitHub API instead of the web UI.

## Checklist

- All 138 backend tests pass
- TypeScript type check passes
- No backend logic changed