### PR TITLE
fix: smoke test fetch timeout + add limit support to HTTP client

### DIFF
--- a/src/backend/client/index.js
+++ b/src/backend/client/index.js
@@ -174,11 +174,18 @@ class ActionsMarketplaceClient {
 
   async _listViaHttp(options = {}) {
     const owner = options.owner;
+    const limit = options.limit;
     let url = `${this.apiUrl}/api/actions/list`;
 
     const query = new URLSearchParams();
     if (owner) {
       query.set('owner', owner);
+    }
+    if (limit != null) {
+      const parsed = Number(limit);
+      if (Number.isFinite(parsed) && parsed > 0) {
+        query.set('limit', String(Math.floor(parsed)));
+      }
     }
     if (this.functionKey) {
       query.set('code', this.functionKey);
@@ -187,12 +194,15 @@ class ActionsMarketplaceClient {
     if (queryString) {
       url += `?${queryString}`;
     }
-    
+
+    const signal = options.signal !== undefined ? options.signal : AbortSignal.timeout(120_000);
+
     const response = await fetch(url, {
       method: 'GET',
       headers: {
         'Accept': 'application/json'
-      }
+      },
+      signal
     });
 
     if (!response.ok) {

--- a/src/backend/examples/list-actions.js
+++ b/src/backend/examples/list-actions.js
@@ -66,8 +66,8 @@ async function main() {
   const { apiHost } = normalizeApiUrl(process.env.API_URL);
   let hadError = false;
 
-  // Example 1: List all actions using HTTP API mode
-  console.log('Example 1: List All Actions (HTTP API Mode)\n');
+  // Example 1: List actions using HTTP API mode (limit=5 keeps smoke test fast)
+  console.log('Example 1: List Actions (HTTP API Mode)\n');
   
   const httpClient = new ActionsMarketplaceClient({
     apiUrl: apiHost,
@@ -75,7 +75,7 @@ async function main() {
   });
 
   try {
-    const actions = await httpClient.listActions();
+    const actions = await httpClient.listActions({ limit: 5 });
     
     console.log(`Found ${actions.length} actions in total\n`);
 

--- a/src/backend/tests/client.test.js
+++ b/src/backend/tests/client.test.js
@@ -403,6 +403,63 @@ describe('ActionsMarketplaceClient', () => {
         );
       });
 
+      it('appends limit to URL when provided', async () => {
+        const client = new ActionsMarketplaceClient({
+          apiUrl: 'https://example.com'
+        });
+
+        const mockFetch = jest.fn().mockResolvedValue({
+          ok: true,
+          json: async () => []
+        });
+        global.fetch = mockFetch;
+
+        await client.listActions({ limit: 10 });
+
+        expect(mockFetch).toHaveBeenCalledWith(
+          'https://example.com/api/actions/list?limit=10',
+          expect.anything()
+        );
+      });
+
+      it('combines owner and limit in URL', async () => {
+        const client = new ActionsMarketplaceClient({
+          apiUrl: 'https://example.com'
+        });
+
+        const mockFetch = jest.fn().mockResolvedValue({
+          ok: true,
+          json: async () => []
+        });
+        global.fetch = mockFetch;
+
+        await client.listActions({ owner: 'actions', limit: 5 });
+
+        expect(mockFetch).toHaveBeenCalledWith(
+          'https://example.com/api/actions/list?owner=actions&limit=5',
+          expect.anything()
+        );
+      });
+
+      it('ignores invalid limit values', async () => {
+        const client = new ActionsMarketplaceClient({
+          apiUrl: 'https://example.com'
+        });
+
+        const mockFetch = jest.fn().mockResolvedValue({
+          ok: true,
+          json: async () => []
+        });
+        global.fetch = mockFetch;
+
+        await client.listActions({ limit: -1 });
+
+        expect(mockFetch).toHaveBeenCalledWith(
+          'https://example.com/api/actions/list',
+          expect.anything()
+        );
+      });
+
       it('throws error on non-200 response', async () => {
         const client = new ActionsMarketplaceClient({
           apiUrl: 'https://example.com'


### PR DESCRIPTION
## Problem

The 'Backend smoke test via client (list actions)' step was failing with:

\\\
Failed to list actions: fetch failed
\\\

after exactly ~10 seconds. Example 1 (\listActions()\ with no filter) tries to download the full ~26 MB dataset. This hit Node.js undici's default 10 s connect timeout — the function app needs time to enumerate all ~30 k records from Table Storage before it can start streaming the response.

## Changes

### \client/index.js\ — \_listViaHttp\
- Added **\limit\ query-string support**: pass \{ limit: N }\ to send \?limit=N\, capping the result set server-side.
- Added **\AbortSignal.timeout(120_000)\ as default signal** on every HTTP fetch to prevent indefinite hangs.

### \xamples/list-actions.js\
- Example 1 now calls \listActions({ limit: 5 })\ — enough to verify the API returns valid data without streaming 26 MB.

### \	ests/client.test.js\
- Added tests for \limit=N\, \owner + limit\, and invalid limit values.

## Notes
The \deploy-frontend\ job's environment URL link was already present in \deploy-app.yml\ (added in c45a00f).