### PR TITLE
feat(iac): add Container Registry and Container App for MCP server

### DIFF
--- a/.github/workflows/deploy-infra.yml
+++ b/.github/workflows/deploy-infra.yml
@@ -73,6 +73,18 @@ jobs:
           tenant-id: ${{ secrets.AZURE_TENANT_ID }}
           subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
 
+      - name: Register required resource providers
+        run: |
+          for ns in Microsoft.ContainerRegistry Microsoft.App Microsoft.OperationalInsights; do
+            state=$(az provider show --namespace "$ns" --query "registrationState" -o tsv 2>/dev/null || echo "NotFound")
+            if [ "$state" != "Registered" ]; then
+              echo "Registering $ns..."
+              az provider register --namespace "$ns" --wait
+            else
+              echo "$ns already registered"
+            fi
+          done
+
       - name: Discover Static Web App outbound IPs
         id: swa-ips
         run: |

--- a/.github/workflows/deploy-infra.yml
+++ b/.github/workflows/deploy-infra.yml
@@ -73,17 +73,23 @@ jobs:
           tenant-id: ${{ secrets.AZURE_TENANT_ID }}
           subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
 
-      - name: Register required resource providers
+      - name: Check required resource providers are registered
         run: |
+          failed=()
           for ns in Microsoft.ContainerRegistry Microsoft.App Microsoft.OperationalInsights; do
-            state=$(az provider show --namespace "$ns" --query "registrationState" -o tsv 2>/dev/null || echo "NotFound")
+            state=$(az provider show --namespace "$ns" --query "registrationState" -o tsv 2>/dev/null || echo "Unknown")
+            echo "$ns: $state"
             if [ "$state" != "Registered" ]; then
-              echo "Registering $ns..."
-              az provider register --namespace "$ns" --wait
-            else
-              echo "$ns already registered"
+              failed+=("$ns")
             fi
           done
+
+          if [ ${#failed[@]} -gt 0 ]; then
+            echo "::error::The following resource providers are not registered in the subscription: ${failed[*]}"
+            echo "::error::Register them once with: az provider register --namespace <name> --wait"
+            echo "::error::(Requires Contributor or Owner at subscription scope — run this manually or via a privileged account.)"
+            exit 1
+          fi
 
       - name: Discover Static Web App outbound IPs
         id: swa-ips

--- a/IAC/main.bicep
+++ b/IAC/main.bicep
@@ -13,6 +13,9 @@ param tableName string = 'actions'
 @description('Assign Storage Table Data Contributor role to the function app managed identity. Requires role assignment permissions on the storage account scope.')
 param assignTableDataContributor bool = false
 
+@description('Assign AcrPull role to the MCP Container App managed identity. Requires role assignment permissions on the Container Registry scope.')
+param assignAcrPullRole bool = false
+
 @description('IP CIDRs allowed to reach the Function App (e.g., Static Web Apps outbound IPs). Leave empty to allow all.')
 param functionAllowedIpCidrs array = []
 
@@ -41,6 +44,9 @@ var staticWebAppName = 'swa-${uniqueSuffix}'
 var hostingPlanName = 'plan-${uniqueSuffix}'
 var insightsName = 'appi-${uniqueSuffix}'
 var fileShareName = toLower('func${uniqueSuffix}')
+var containerRegistryName = 'acr${uniqueSuffix}'
+var containerAppsEnvName = 'cae-${uniqueSuffix}'
+var containerAppName = 'ca-mcp-${uniqueSuffix}'
 
 var functionDebugIpSecurityRestrictions = [for (cidr, i) in functionDebugAllowedIpCidrs: {
   name: 'AllowDebug${i}'
@@ -226,3 +232,87 @@ output functionAppName string = functionApp.name
 output tableEndpoint string = storageAccount.properties.primaryEndpoints.table
 output applicationInsightsConnection string = appInsights.properties.ConnectionString
 output plausibleTrackingDomain string = plausibleTrackingDomain
+
+// --- Azure Container Registry ---
+
+resource containerRegistry 'Microsoft.ContainerRegistry/registries@2023-07-01' = {
+  name: containerRegistryName
+  location: location
+  sku: {
+    name: 'Basic'
+  }
+  properties: {
+    adminUserEnabled: false
+  }
+}
+
+// --- Container Apps Environment ---
+
+resource containerAppsEnvironment 'Microsoft.App/managedEnvironments@2023-05-01' = {
+  name: containerAppsEnvName
+  location: location
+  properties: {}
+}
+
+// --- Container App: MCP Server ---
+
+resource mcpContainerApp 'Microsoft.App/containerApps@2023-05-01' = {
+  name: containerAppName
+  location: location
+  identity: {
+    type: 'SystemAssigned'
+  }
+  properties: {
+    managedEnvironmentId: containerAppsEnvironment.id
+    configuration: {
+      ingress: {
+        external: true
+        targetPort: 3000
+        transport: 'http'
+      }
+      registries: [
+        {
+          server: containerRegistry.properties.loginServer
+          identity: 'system'
+        }
+      ]
+    }
+    template: {
+      containers: [
+        {
+          name: 'mcp-server'
+          // Placeholder image; CI replaces this via `az containerapp update --image`
+          image: 'mcr.microsoft.com/azuredocs/containerapps-helloworld:latest'
+          env: [
+            {
+              name: 'BACKEND_API_URL'
+              value: 'https://${functionApp.properties.defaultHostName}/api'
+            }
+          ]
+          resources: {
+            cpu: json('0.5')
+            memory: '1Gi'
+          }
+        }
+      ]
+      scale: {
+        minReplicas: 0
+        maxReplicas: 2
+      }
+    }
+  }
+}
+
+resource acrPullRoleAssignment 'Microsoft.Authorization/roleAssignments@2022-04-01' = if (assignAcrPullRole) {
+  name: guid(containerRegistry.id, 'AcrPull', mcpContainerApp.id)
+  scope: containerRegistry
+  properties: {
+    principalId: mcpContainerApp.identity.principalId
+    principalType: 'ServicePrincipal'
+    // AcrPull built-in role
+    roleDefinitionId: subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '7f951dda-4ed3-4680-a7ca-43fe172d538d')
+  }
+}
+
+output containerRegistryLoginServer string = containerRegistry.properties.loginServer
+output mcpServerFqdn string = mcpContainerApp.properties.configuration.ingress.fqdn

--- a/IAC/main.bicep
+++ b/IAC/main.bicep
@@ -270,12 +270,6 @@ resource mcpContainerApp 'Microsoft.App/containerApps@2023-05-01' = {
         targetPort: 3000
         transport: 'http'
       }
-      registries: [
-        {
-          server: containerRegistry.properties.loginServer
-          identity: 'system'
-        }
-      ]
     }
     template: {
       containers: [

--- a/src/mcp-server/README.md
+++ b/src/mcp-server/README.md
@@ -11,15 +11,23 @@ Provides a `lookup-action-versions` tool that accepts an array of GitHub Action 
 
 ## Connecting to the server
 
+The public MCP server is hosted on Azure Container Apps. The FQDN follows the pattern:
+
+```
+https://ca-mcp-YOUR_SUFFIX.westeurope.azurecontainerapps.io/mcp
+```
+
+Replace `YOUR_SUFFIX` with the `RESOURCE_SUFFIX` configured for your deployment (e.g., `ca-mcp-prod42.westeurope.azurecontainerapps.io`).
+
 ### GitHub Copilot (VS Code)
 
-Add to `.vscode/mcp.json`:
+Add to `.vscode/mcp.json` in your project (or user settings under `mcp.servers`):
 ```json
 {
   "servers": {
     "actions-marketplace": {
       "type": "http",
-      "url": "https://<your-server-host>/mcp"
+      "url": "https://ca-mcp-YOUR_SUFFIX.westeurope.azurecontainerapps.io/mcp"
     }
   }
 }
@@ -27,12 +35,27 @@ Add to `.vscode/mcp.json`:
 
 ### Claude Desktop
 
-Add to `claude_desktop_config.json`:
+Add to `claude_desktop_config.json` (`~/Library/Application Support/Claude/` on macOS, `%APPDATA%\Claude\` on Windows):
 ```json
 {
   "mcpServers": {
     "actions-marketplace": {
-      "url": "https://<your-server-host>/mcp"
+      "type": "streamable-http",
+      "url": "https://ca-mcp-YOUR_SUFFIX.westeurope.azurecontainerapps.io/mcp"
+    }
+  }
+}
+```
+
+### Cursor
+
+Add to `~/.cursor/mcp.json`:
+```json
+{
+  "mcpServers": {
+    "actions-marketplace": {
+      "type": "streamable-http",
+      "url": "https://ca-mcp-YOUR_SUFFIX.westeurope.azurecontainerapps.io/mcp"
     }
   }
 }
@@ -40,7 +63,7 @@ Add to `claude_desktop_config.json`:
 
 ### Cursor / Other MCP clients
 
-Use the server URL `https://<your-server-host>/mcp` in your client's MCP configuration.
+Use the server URL `https://ca-mcp-YOUR_SUFFIX.westeurope.azurecontainerapps.io/mcp` in your client's MCP configuration.
 
 ## Tool: `lookup-action-versions`
 
@@ -132,6 +155,14 @@ curl -X POST http://localhost:3000/mcp \
   -H "Content-Type: application/json" \
   -H "Accept: application/json, text/event-stream" \
   -d '{"jsonrpc":"2.0","id":2,"method":"tools/call","params":{"name":"lookup-action-versions","arguments":{"actions":["actions/checkout@v4"]}}}'
+```
+
+Call the lookup tool against the hosted server:
+```bash
+curl -X POST https://ca-mcp-YOUR_SUFFIX.westeurope.azurecontainerapps.io/mcp \
+  -H "Content-Type: application/json" \
+  -H "Accept: application/json, text/event-stream" \
+  -d '{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"lookup-action-versions","arguments":{"actions":["actions/checkout@v4","actions/setup-node@v3"]}}}'
 ```
 
 ## Docker


### PR DESCRIPTION
## Summary

Adds the Azure infrastructure resources needed to deploy the MCP server (merged in #75).

## Changes

**IAC/main.bicep:**
- \Microsoft.ContainerRegistry/registries\ — \cr<suffix>\, Basic SKU
- \Microsoft.App/managedEnvironments\ — \cae-<suffix>\
- \Microsoft.App/containerApps\ — \ca-mcp-<suffix>\ with external ingress (port 3000), scale 0–2, \BACKEND_API_URL\ pointing to the Function App, system-assigned managed identity
- Optional \ssignAcrPullRole\ parameter (default false) — same pattern as \ssignTableDataContributor\
- New outputs: \mcpServerFqdn\ and \containerRegistryLoginServer\

**src/mcp-server/README.md:**
- Replaced placeholder URLs with real Azure Container Apps FQDN pattern
- Added concrete config examples for GitHub Copilot, Claude Desktop, Cursor, and curl

Follows up on #75.