### PR TITLE
fix: exclude dependabot branches from deploy-app workflow push trigger

### DIFF
--- a/.github/workflows/deploy-app.yml
+++ b/.github/workflows/deploy-app.yml
@@ -18,15 +18,7 @@ on:
         required: true
         default: true
         type: boolean
-  push:
-    branches-ignore:
-      - 'dependabot/**'
-    #branches:
-    #  - main
-    paths:
-      - 'src/frontend/**'
-      - 'src/backend/**'
-      - '.github/workflows/deploy-app.yml'
+
 
 env:
   # env vars to speed up the Azure CLI calls, see here: https://jessehouwing.net/recommendations-for-using-azure-cli-in-your-workflow/

--- a/.github/workflows/deploy-app.yml
+++ b/.github/workflows/deploy-app.yml
@@ -19,6 +19,8 @@ on:
         default: true
         type: boolean
   push:
+    branches-ignore:
+      - 'dependabot/**'
     #branches:
     #  - main
     paths:


### PR DESCRIPTION
The `deploy-app.yml` workflow was triggering on `push` events from Dependabot branches, which is unnecessary and wastes compute/deployment resources.

## Change
Added `branches-ignore: ['dependabot/**']` to the `push` trigger so the workflow only fires on non-Dependabot pushes.