### PR TITLE
ci: add code quality workflow and configure branch ruleset for main

### DIFF
--- a/.github/workflows/code-quality.yml
+++ b/.github/workflows/code-quality.yml
@@ -1,0 +1,38 @@
+name: Code Quality
+
+on:
+  push:
+    branches: ['**']
+  pull_request:
+    branches: ['**']
+
+jobs:
+  lint-and-typecheck:
+    name: Code Quality
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js 22
+        uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+          cache: 'npm'
+          cache-dependency-path: '**/package-lock.json'
+
+      - name: Install backend dependencies
+        working-directory: src/backend
+        run: npm ci
+
+      - name: Lint backend
+        working-directory: src/backend
+        run: npm run lint
+
+      - name: Install frontend dependencies
+        working-directory: src/frontend
+        run: npm ci
+
+      - name: Type-check frontend
+        working-directory: src/frontend
+        run: npx tsc --noEmit


### PR DESCRIPTION
## Summary

Configures branch protection for `main` and adds a code quality workflow.

### Branch Ruleset — "Protect main" (already active)
- **Target:** `refs/heads/main`
- **Requires a PR** — 0 approvals (sole maintainer), no stale review dismissal
- **Bypass:** `rajbos` always
- **Blocks:** force-push and branch deletion
- **Required status checks:**
  - `build-and-test` (swa-test workflow — backend tests + frontend build, always runs on PRs)
  - `Build` (Staged Deploy workflow — builds frontend + backend, always runs on PRs)
  - `CodeQL` (GitHub default code scanning — JS/TS/Actions)
  - `Code Quality` (new workflow added in this PR)

### New: `.github/workflows/code-quality.yml`
- Runs on every push and PR
- **Backend:** ESLint via `npm run lint`
- **Frontend:** TypeScript type-check via `tsc --noEmit`
- Job is named `Code Quality` to match the required status check

### Notes
- Text-only PRs (e.g. README edits) will still trigger all checks — they all pass without Azure credentials
- Path-filtered workflows (`deploy-mcp-server`) are intentionally excluded from required checks to avoid blocking unrelated PRs