### PR TITLE
Potential fix for code scanning alert no. 4: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/swa-test.yml
+++ b/.github/workflows/swa-test.yml
@@ -8,6 +8,9 @@ on:
     branches:
       - '**'
 
+permissions:
+  contents: read
+
 jobs:
   build-and-test:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/devops-actions/alternative-github-actions-marketplace/security/code-scanning/4](https://github.com/devops-actions/alternative-github-actions-marketplace/security/code-scanning/4)

Add an explicit `permissions` block at the workflow root so all jobs inherit least-privilege defaults unless overridden. For this workflow, the minimal required scope is `contents: read` (sufficient for `actions/checkout` and read-only repo access). This preserves current behavior while preventing accidental broader token access if repo/org defaults change.

**File to change:** `.github/workflows/swa-test.yml`  
**Region:** near the top-level keys, after `on:` (or before `jobs:`).  
**Change:** add:

```yml
permissions:
  contents: read
```

No imports, methods, or dependencies are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
