### PR TITLE
fix: update dependabot npm directories to match actual package locations

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,7 +10,17 @@ updates:
     schedule:
       interval: "weekly"
 
-  - package-ecosystem: "npm" # See documentation for possible values
-    directory: "/" # Location of package manifests
+  - package-ecosystem: "npm"
+    directory: "/src/frontend"
+    schedule:
+      interval: "weekly"
+
+  - package-ecosystem: "npm"
+    directory: "/src/backend"
+    schedule:
+      interval: "weekly"
+
+  - package-ecosystem: "npm"
+    directory: "/src/mcp-server"
     schedule:
       interval: "weekly"


### PR DESCRIPTION
The npm entry was pointing to / where no package.json exists (only a package-lock.json), so Dependabot was not tracking any npm dependencies.

## Changes
- Remove incorrect npm entry at /
- Add npm entries for the three actual package locations:
  - /src/frontend
  - /src/backend
  - /src/mcp-server

The github-actions entry at / is unchanged and correct.