### PR TITLE
fix: configure Container App to use managed identity for ACR pull

### DIFF
--- a/.github/workflows/deploy-infra.yml
+++ b/.github/workflows/deploy-infra.yml
@@ -178,6 +178,40 @@ jobs:
           parameters: /tmp/deploy-params.json
           failOnStdErr: false
 
+      - name: Grant AcrPull role to Container App managed identity
+        run: |
+          set -e
+          caName="ca-mcp-${{ vars.RESOURCE_SUFFIX }}"
+          acrName="acr${{ vars.RESOURCE_SUFFIX }}"
+
+          principalId=$(az containerapp show \
+            --name "$caName" \
+            --resource-group "${{ vars.AZURE_RESOURCE_GROUP }}" \
+            --query "identity.principalId" -o tsv 2>/dev/null || true)
+
+          if [ -z "$principalId" ]; then
+            echo "::warning::Could not retrieve Container App managed identity principal ID; skipping AcrPull role assignment."
+            exit 0
+          fi
+
+          acrId=$(az acr show \
+            --name "$acrName" \
+            --resource-group "${{ vars.AZURE_RESOURCE_GROUP }}" \
+            --query "id" -o tsv)
+
+          # Idempotent: ignore if assignment already exists
+          if az role assignment create \
+            --assignee-object-id "$principalId" \
+            --assignee-principal-type ServicePrincipal \
+            --role AcrPull \
+            --scope "$acrId" 2>/dev/null; then
+            echo "AcrPull role granted to $caName managed identity on $acrName."
+          else
+            echo "::warning::Could not create AcrPull role assignment (deployment identity may lack Microsoft.Authorization/roleAssignments/write)."
+            echo "::warning::Grant it manually:"
+            echo "::warning::  az role assignment create --assignee-object-id $principalId --assignee-principal-type ServicePrincipal --role AcrPull --scope $acrId"
+          fi
+
       - name: Validate deployed resource names match expected suffix
         env:
           EXPECTED_SUFFIX: ${{ vars.RESOURCE_SUFFIX }}

--- a/IAC/main.bicep
+++ b/IAC/main.bicep
@@ -265,6 +265,12 @@ resource mcpContainerApp 'Microsoft.App/containerApps@2023-05-01' = {
   properties: {
     managedEnvironmentId: containerAppsEnvironment.id
     configuration: {
+      registries: [
+        {
+          server: containerRegistry.properties.loginServer
+          identity: 'system'
+        }
+      ]
       ingress: {
         external: true
         targetPort: 3000


### PR DESCRIPTION
## Problem

Container App deployment failed with `UNAUTHORIZED: authentication required` when pulling `acrwsg6po7n4p5dg.azurecr.io/mcp-server:<sha>`.

Two root causes:

1. **Missing `registries` config** — the Container App had no instruction to use its system-assigned managed identity to authenticate against ACR. Without this, Container Apps falls back to anonymous auth, which fails for private registries.
2. **AcrPull role never granted** — `assignAcrPullRole` defaults to `false` and was never passed in the deploy workflow, so the managed identity had no pull permissions on the ACR.

## Fix

### `IAC/main.bicep`
Added `registries` block to the Container App configuration so it explicitly uses the system-assigned managed identity for the ACR:

```bicep
registries: [
  {
    server: containerRegistry.properties.loginServer
    identity: 'system'
  }
]
```

### `.github/workflows/deploy-infra.yml`
Added a **Grant AcrPull role** step after the Bicep deployment that:
- Looks up the Container App's managed identity principal ID
- Idempotently creates the `AcrPull` role assignment on the ACR
- Gracefully falls back to a warning with the manual `az role assignment create` command if the deployment identity lacks `Microsoft.Authorization/roleAssignments/write`

## After merging

Re-run the **Deploy IaC** workflow to apply the `registries` config and grant the role. Then re-run **Deploy MCP Server** — the image pull should succeed.