### PR TITLE
fix: ensure AcrPull role before MCP Container App deploy

### DIFF
--- a/.github/workflows/deploy-infra.yml
+++ b/.github/workflows/deploy-infra.yml
@@ -199,7 +199,6 @@ jobs:
             --resource-group "${{ vars.AZURE_RESOURCE_GROUP }}" \
             --query "id" -o tsv)
 
-          # Idempotent: ignore if assignment already exists
           if az role assignment create \
             --assignee-object-id "$principalId" \
             --assignee-principal-type ServicePrincipal \
@@ -207,9 +206,18 @@ jobs:
             --scope "$acrId" 2>/dev/null; then
             echo "AcrPull role granted to $caName managed identity on $acrName."
           else
-            echo "::warning::Could not create AcrPull role assignment (deployment identity may lack Microsoft.Authorization/roleAssignments/write)."
-            echo "::warning::Grant it manually:"
-            echo "::warning::  az role assignment create --assignee-object-id $principalId --assignee-principal-type ServicePrincipal --role AcrPull --scope $acrId"
+            existing=$(az role assignment list \
+              --assignee "$principalId" \
+              --role AcrPull \
+              --scope "$acrId" \
+              --query "length(@)" -o tsv 2>/dev/null || echo "0")
+            if [ "$existing" -gt 0 ]; then
+              echo "AcrPull role already assigned; nothing to do."
+            else
+              echo "::error::Could not create AcrPull role assignment (deployment identity may lack Microsoft.Authorization/roleAssignments/write)."
+              echo "::error::Grant it manually: az role assignment create --assignee-object-id $principalId --assignee-principal-type ServicePrincipal --role AcrPull --scope $acrId"
+              exit 1
+            fi
           fi
 
       - name: Validate deployed resource names match expected suffix

--- a/.github/workflows/deploy-mcp-server.yml
+++ b/.github/workflows/deploy-mcp-server.yml
@@ -130,6 +130,48 @@ jobs:
 
           echo "IMAGE_TAG=$imageTag" >> "$GITHUB_ENV"
 
+      - name: Ensure AcrPull role on Container App managed identity
+        run: |
+          set -e
+          caName="ca-mcp-${{ vars.RESOURCE_SUFFIX }}"
+          acrName="acr${{ vars.RESOURCE_SUFFIX }}"
+
+          principalId=$(az containerapp show \
+            --name "$caName" \
+            --resource-group "${{ vars.AZURE_RESOURCE_GROUP }}" \
+            --query "identity.principalId" -o tsv 2>/dev/null || true)
+
+          if [ -z "$principalId" ]; then
+            echo "::error::Could not retrieve Container App managed identity; AcrPull role assignment skipped."
+            exit 1
+          fi
+
+          acrId=$(az acr show \
+            --name "$acrName" \
+            --resource-group "${{ vars.AZURE_RESOURCE_GROUP }}" \
+            --query "id" -o tsv)
+
+          if az role assignment create \
+            --assignee-object-id "$principalId" \
+            --assignee-principal-type ServicePrincipal \
+            --role AcrPull \
+            --scope "$acrId" 2>/dev/null; then
+            echo "AcrPull role granted to $caName managed identity on $acrName."
+          else
+            existing=$(az role assignment list \
+              --assignee "$principalId" \
+              --role AcrPull \
+              --scope "$acrId" \
+              --query "length(@)" -o tsv 2>/dev/null || echo "0")
+            if [ "$existing" -gt 0 ]; then
+              echo "AcrPull role already assigned; nothing to do."
+            else
+              echo "::error::Could not create AcrPull role assignment (deployment identity may lack Microsoft.Authorization/roleAssignments/write)."
+              echo "::error::Grant it manually: az role assignment create --assignee-object-id $principalId --assignee-principal-type ServicePrincipal --role AcrPull --scope $acrId"
+              exit 1
+            fi
+          fi
+
       - name: Deploy to Container App
         run: |
           caName="ca-mcp-${{ vars.RESOURCE_SUFFIX }}"


### PR DESCRIPTION
## Problem

The MCP server deployment was failing with:
```
unable to pull image using Managed identity system for registry acrwsg6po7n4p5dg.azurecr.io
```

The Container App uses its System Assigned Managed Identity to pull images from ACR, but that identity was never granted the `AcrPull` role.

`deploy-infra.yml` has a "Grant AcrPull role" step, but it **soft-fails silently** — if the deployment identity lacks `Microsoft.Authorization/roleAssignments/write`, it only emits a `::warning::` and the step passes. Infra deploys green, role is never assigned, next MCP deploy fails.

`deploy-mcp-server.yml` had no role check at all.

## Changes

### `deploy-mcp-server.yml`
- Add **"Ensure AcrPull role on Container App managed identity"** step before the deploy step
- Self-contained: the MCP workflow no longer relies on the infra deploy having previously run
- Idempotent: checks for an existing assignment before treating a creation failure as an error
- Fails the workflow (`exit 1`) if the role is missing and cannot be assigned — better than proceeding to a deploy that will definitely fail

### `deploy-infra.yml`
- Harden the existing Grant AcrPull step: emit `::error::` and `exit 1` when the role cannot be assigned and is not already present
- Same idempotency check (existing assignment = success)
- Removes the silent soft-fail that masked the missing role for past deployments