### PR TITLE
fix: shorten MCP server name to prevent tool name truncation

### DIFF
--- a/src/mcp-server/lib/mcpServer.js
+++ b/src/mcp-server/lib/mcpServer.js
@@ -9,7 +9,7 @@ const { lookupActions, MAX_BATCH_SIZE } = require('./actionLookup');
  */
 function createMcpServer() {
   const server = new McpServer({
-    name: 'actions-marketplace',
+    name: 'actions-mkt',
     version: '1.0.0'
   });
 


### PR DESCRIPTION
MCP clients enforce a 40-character limit on tool names. The previous server name `actions-marketplace` produced the combined tool name `mcp_actions-marketplace_lookup-action-versions` (46 chars), which clients silently truncated to `mcp_actions-marke_lookup-action-versions` -- breaking discoverability and invocation.

Renaming the server to `actions-mkt` yields `mcp_actions-mkt_lookup-action-versions` (38 chars), safely under the limit.

The `"actions-marketplace"` keys in the README config examples are client-side aliases chosen by the user in their own MCP config files, so they are unaffected by this change.