### PR TITLE
fix(mcp): correctly handle isLatest and currentVersionTag for SHA-pinned action inputs

### DIFF
--- a/src/mcp-server/lib/actionLookup.js
+++ b/src/mcp-server/lib/actionLookup.js
@@ -8,6 +8,19 @@ const { logToolCall } = require('./monitoring');
 const MAX_BATCH_SIZE = 20;
 
 /**
+ * Resolve the version string for a given commit SHA using a reverse lookup of versionShaMap.
+ * Returns the matching version tag (e.g. "v2.19.1") or null if not found.
+ */
+function resolveVersionFromSha(actionData, sha) {
+  if (!sha) return null;
+  const shaMap = actionData.versionShaMap;
+  if (!shaMap || typeof shaMap !== 'object') return null;
+  const normalizedSha = sha.toLowerCase();
+  const entry = Object.entries(shaMap).find(([, s]) => s && s.toLowerCase() === normalizedSha);
+  return entry ? entry[0] : null;
+}
+
+/**
  * Resolve the commit SHA for a given version using versionShaMap or legacy tagInfo objects.
  * Returns null if no SHA can be found.
  */
@@ -105,7 +118,7 @@ async function lookupSingleAction(parsed) {
     };
   }
 
-  const { owner, name, version, raw } = parsed;
+  const { owner, name, version, isHash, raw } = parsed;
 
   // Check cache first
   let actionData = getAction(owner, name);
@@ -124,6 +137,7 @@ async function lookupSingleAction(parsed) {
         latestVersion: null,
         commitSha: null,
         currentVersion: version,
+        currentVersionTag: null,
         isLatest: null,
         allVersions: []
       };
@@ -144,6 +158,7 @@ async function lookupSingleAction(parsed) {
       latestVersion: null,
       commitSha: null,
       currentVersion: version,
+      currentVersionTag: null,
       isLatest: null,
       allVersions: []
     };
@@ -151,7 +166,13 @@ async function lookupSingleAction(parsed) {
 
   logToolCall(owner, name, raw);
 
-  const { latestVersion, allVersions, isLatest } = resolveLatestVersion(actionData, version);
+  // For SHA-pinned inputs, resolve the version tag the SHA corresponds to.
+  // Pass null when unresolvable so resolveLatestVersion returns isLatest: null (unknown)
+  // rather than false (definitely not latest).
+  const currentVersionTag = isHash ? resolveVersionFromSha(actionData, version) : null;
+  const versionForComparison = isHash ? currentVersionTag : version;
+
+  const { latestVersion, allVersions, isLatest } = resolveLatestVersion(actionData, versionForComparison);
   const commitSha = resolveCommitSha(actionData, latestVersion);
 
   return {
@@ -163,6 +184,7 @@ async function lookupSingleAction(parsed) {
     latestVersion,
     commitSha,
     currentVersion: version,
+    currentVersionTag,
     isLatest,
     allVersions,
     cacheHit
@@ -192,4 +214,4 @@ async function lookupActions(actions) {
   return { results };
 }
 
-module.exports = { lookupActions, lookupSingleAction, resolveLatestVersion, resolveCommitSha, MAX_BATCH_SIZE };
+module.exports = { lookupActions, lookupSingleAction, resolveLatestVersion, resolveCommitSha, resolveVersionFromSha, MAX_BATCH_SIZE };

--- a/src/mcp-server/test/actionLookup.test.js
+++ b/src/mcp-server/test/actionLookup.test.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const { resolveLatestVersion, resolveCommitSha } = require('../lib/actionLookup');
+const { resolveLatestVersion, resolveCommitSha, resolveVersionFromSha } = require('../lib/actionLookup');
 
 describe('resolveLatestVersion', () => {
   test('returns latest from releaseInfo (newest-first)', () => {
@@ -92,5 +92,71 @@ describe('resolveCommitSha', () => {
       versionShaMap: { 'v4.0.0': 'abc123' }
     };
     expect(resolveCommitSha(actionData, null)).toBeNull();
+  });
+});
+
+describe('resolveVersionFromSha', () => {
+  test('returns version tag when SHA is found in versionShaMap', () => {
+    const actionData = { versionShaMap: { 'v2.19.1': 'a5ad31d6abc', 'v2.0.0': 'deadbeef' } };
+    expect(resolveVersionFromSha(actionData, 'a5ad31d6abc')).toBe('v2.19.1');
+  });
+
+  test('returns null when SHA is not in versionShaMap', () => {
+    const actionData = { versionShaMap: { 'v1.0.0': 'abc123' } };
+    expect(resolveVersionFromSha(actionData, 'notinmap')).toBeNull();
+  });
+
+  test('returns null when versionShaMap is missing', () => {
+    expect(resolveVersionFromSha({}, 'abc123')).toBeNull();
+  });
+
+  test('returns null when sha is null', () => {
+    const actionData = { versionShaMap: { 'v1.0.0': 'abc123' } };
+    expect(resolveVersionFromSha(actionData, null)).toBeNull();
+  });
+
+  test('is case-insensitive for SHA comparison', () => {
+    const actionData = { versionShaMap: { 'v1.0.0': 'ABC123DEF' } };
+    expect(resolveVersionFromSha(actionData, 'abc123def')).toBe('v1.0.0');
+  });
+});
+
+describe('SHA-pinned isLatest via lookupSingleAction', () => {
+  // These tests verify the plumbing in lookupSingleAction by combining the pure helpers
+  // directly, covering the same logical paths without fragile module mocking.
+
+  test('resolveVersionFromSha + resolveLatestVersion: null versionShaMap yields isLatest null', () => {
+    const actionData = { releaseInfo: ['v4.2.2', 'v4.2.1'], tagInfo: [] };
+    const sha = 'de0fac2e4500dabe';
+    const resolved = resolveVersionFromSha(actionData, sha); // null (no map)
+    const { isLatest } = resolveLatestVersion(actionData, resolved); // null (no currentVersion)
+    expect(resolved).toBeNull();
+    expect(isLatest).toBeNull();
+  });
+
+  test('resolveVersionFromSha + resolveLatestVersion: SHA resolves to latest -> isLatest true', () => {
+    const actionData = {
+      releaseInfo: ['v4.2.2', 'v4.2.1'],
+      tagInfo: [],
+      versionShaMap: { 'v4.2.2': 'de0fac2e4500dabe', 'v4.2.1': 'abc' }
+    };
+    const sha = 'de0fac2e4500dabe';
+    const resolved = resolveVersionFromSha(actionData, sha);
+    const { isLatest } = resolveLatestVersion(actionData, resolved);
+    expect(resolved).toBe('v4.2.2');
+    expect(isLatest).toBe(true);
+  });
+
+  test('resolveVersionFromSha + resolveLatestVersion: SHA resolves to older version -> isLatest false', () => {
+    const actionData = {
+      releaseInfo: ['v4.2.2', 'v4.2.1'],
+      tagInfo: [],
+      versionShaMap: { 'v4.2.2': 'de0fac2e4500dabe', 'v4.2.1': 'oldsha' }
+    };
+    const sha = 'oldsha';
+    const resolved = resolveVersionFromSha(actionData, sha);
+    const { isLatest } = resolveLatestVersion(actionData, resolved);
+    expect(resolved).toBe('v4.2.1');
+    expect(isLatest).toBe(false);
   });
 });


### PR DESCRIPTION
## Problem

When users query SHA-pinned actions (e.g. `actions/checkout@de0fac2e...`), the MCP output had two completeness issues:

1. **`isLatest: false` was always returned for SHA pins** — The code compared the raw SHA string to version tags like `v3.1.0`, which never match, so `isLatest` was always `false` even if the SHA actually corresponded to the latest version.

2. **`currentVersionTag` was missing** — There was no way for the LLM consumer to know which version tag (e.g. `v2.19.1`) a pinned SHA corresponds to.

Note: `commitSha: null` for the latest version is a separate data-pipeline issue (the external indexer hasn't populated `versionShaMap` in production yet) — no code fix needed here.

## Changes

- **`resolveVersionFromSha(actionData, sha)`** — new helper that reverse-looks up a commit SHA in `versionShaMap` and returns the matching version tag.
- **`lookupSingleAction`** — when the input is a hash (`isHash: true`), resolve the SHA to a version tag first, then pass that tag (or `null` if unresolvable) to `resolveLatestVersion`. This means:
  - SHA with `versionShaMap` present → `isLatest` is correctly `true`/`false`
  - SHA with no `versionShaMap` data → `isLatest: null` (unknown, not the misleading `false`)
- **`currentVersionTag`** — added to the response (the resolved version tag for hash inputs, `null` for tag/branch inputs).

## Example output change

Before:
```json
{ "currentVersion": "a5ad31d6...", "isLatest": false, "commitSha": null }
```

After (no `versionShaMap` in data):
```json
{ "currentVersion": "a5ad31d6...", "currentVersionTag": null, "isLatest": null, "commitSha": null }
```

After (with `versionShaMap` populated by indexer):
```json
{ "currentVersion": "a5ad31d6...", "currentVersionTag": "v2.19.1", "isLatest": true, "commitSha": "a5ad31d6..." }
```