### PR TITLE
feat: add custom domain support for marketplace SWA and MCP Container App

### DIFF
--- a/.github/workflows/deploy-infra.yml
+++ b/.github/workflows/deploy-infra.yml
@@ -138,6 +138,8 @@ jobs:
           DEPLOY_LOCATION: ${{ vars.DEPLOY_LOCATION }}
           STATIC_WEB_APP_LOCATION: ${{ vars.STATIC_WEB_APP_LOCATION }}
           PLAUSIBLE_TRACKING_DOMAIN: ${{ vars.PLAUSIBLE_TRACKING_DOMAIN }}
+          SWA_CUSTOM_DOMAIN: ${{ vars.SWA_CUSTOM_DOMAIN }}
+          MCP_CUSTOM_DOMAIN: ${{ vars.MCP_CUSTOM_DOMAIN }}
           RESOURCE_SUFFIX: ${{ vars.RESOURCE_SUFFIX }}
           SWA_HOSTNAME: ${{ steps.swa-ips.outputs.swa_hostname }}
           OUTBOUND_IPS_JSON: ${{ steps.swa-ips.outputs.outbound_ips_json }}
@@ -163,6 +165,8 @@ jobs:
           [ -n "$DEPLOY_LOCATION" ]          && params=$(echo "$params" | jq --arg v "$DEPLOY_LOCATION"          '.parameters.location                 = { "value": $v }')
           [ -n "$STATIC_WEB_APP_LOCATION" ]  && params=$(echo "$params" | jq --arg v "$STATIC_WEB_APP_LOCATION"  '.parameters.staticWebAppLocation      = { "value": $v }')
           [ -n "$PLAUSIBLE_TRACKING_DOMAIN" ] && params=$(echo "$params" | jq --arg v "$PLAUSIBLE_TRACKING_DOMAIN" '.parameters.plausibleTrackingDomain  = { "value": $v }')
+          [ -n "$SWA_CUSTOM_DOMAIN" ]        && params=$(echo "$params" | jq --arg v "$SWA_CUSTOM_DOMAIN"        '.parameters.swaCustomDomain           = { "value": $v }')
+          [ -n "$MCP_CUSTOM_DOMAIN" ]        && params=$(echo "$params" | jq --arg v "$MCP_CUSTOM_DOMAIN"        '.parameters.mcpCustomDomain           = { "value": $v }')
 
           echo "$params" > /tmp/deploy-params.json
           echo "Deployment parameters:"

--- a/IAC/README.md
+++ b/IAC/README.md
@@ -26,12 +26,61 @@ The `main.bicep` template deploys:
 | `staticWebAppHostname` | Static Web App hostname for CORS configuration | `''` | No |
 | `functionCorsAllowedOrigins` | CORS allowed origins for the Function App | `['https://portal.azure.com']` | No |
 | `plausibleTrackingDomain` | Custom domain for Plausible Analytics tracking | `''` | No |
+| `swaCustomDomain` | Custom domain for the Static Web App (e.g., `marketplace.devopsjournal.io`) | `''` | No |
+| `mcpCustomDomain` | Custom domain for the MCP Container App (e.g., `actions-mcp.devopsjournal.io`) | `''` | No |
 
 ## Custom Domain Configuration
 
-The template supports configuring a custom domain on the Static Web App for Plausible Analytics tracking.
+### Marketplace Website (`marketplace.devopsjournal.io` → SWA)
 
-### Setup
+**Step 1 — Create DNS record first** (before deploying Bicep):
+
+```
+CNAME  marketplace  →  <swa-default-hostname>.azurestaticapps.net
+```
+
+Get the default hostname from the Azure portal or:
+```bash
+az staticwebapp show --name swa-<suffix> --resource-group <rg> --query defaultHostname -o tsv
+```
+
+**Step 2 — Set repository variable:**
+```
+SWA_CUSTOM_DOMAIN=marketplace.devopsjournal.io
+```
+
+**Step 3 — Deploy:** The `deploy-infra.yml` workflow passes `swaCustomDomain` to Bicep, which creates the custom domain resource using CNAME delegation. Azure issues the managed TLS certificate automatically (no TXT record needed for subdomain CNAME delegation).
+
+---
+
+### MCP Server (`actions-mcp.devopsjournal.io` → Container App)
+
+This requires a **two-step process** because the managed certificate needs DNS to exist before it can be issued.
+
+**Step 1 — Get the verification ID** (first deploy without custom domain set):
+```bash
+az containerapp show \
+  --name ca-mcp-<suffix> \
+  --resource-group <rg> \
+  --query "properties.customDomainVerificationId" -o tsv
+```
+
+**Step 2 — Create DNS records:**
+```
+CNAME  actions-mcp   →  ca-mcp-<suffix>.ashyplant-207692d4.westeurope.azurecontainerapps.io
+TXT    asuid.actions-mcp  →  <verification-id-from-step-1>
+```
+
+**Step 3 — Set repository variable:**
+```
+MCP_CUSTOM_DOMAIN=actions-mcp.devopsjournal.io
+```
+
+**Step 4 — Deploy again:** Bicep creates the managed certificate and binds it to the Container App ingress. Azure validates via CNAME and issues the TLS cert.
+
+---
+
+### Plausible Analytics Custom Domain (`plausibleTrackingDomain`)
 
 1. **Set repository variable**: Configure `PLAUSIBLE_TRACKING_DOMAIN` with your custom domain:
    ```
@@ -111,3 +160,6 @@ az deployment group create \
 | `tableEndpoint` | Table Storage endpoint URL |
 | `applicationInsightsConnection` | Application Insights connection string |
 | `plausibleTrackingDomain` | The configured Plausible tracking domain |
+| `containerRegistryLoginServer` | ACR login server hostname |
+| `mcpServerFqdn` | Container App default FQDN |
+| `mcpCustomDomainVerificationId` | Verification ID for Container App custom domain TXT record (`asuid.<subdomain>`) |

--- a/IAC/main.bicep
+++ b/IAC/main.bicep
@@ -33,6 +33,12 @@ param functionCorsAllowedOrigins array = [
 @description('Plausible Analytics tracking domain. This domain will be used for analytics tracking on the frontend. Leave empty to disable Plausible tracking.')
 param plausibleTrackingDomain string = ''
 
+@description('Custom domain for the Static Web App (e.g., marketplace.devopsjournal.io). Leave empty to skip. Requires a CNAME record pointing to the SWA default hostname before deployment.')
+param swaCustomDomain string = ''
+
+@description('Custom domain for the MCP Container App (e.g., actions-mcp.devopsjournal.io). Leave empty to skip. Requires DNS set up before deployment: CNAME to the Container App FQDN and TXT asuid.<subdomain> with the Container App verification ID.')
+param mcpCustomDomain string = ''
+
 @description('Required. Fixed suffix for all resource names. Set via the RESOURCE_SUFFIX repository variable. All resources will be named with this suffix (e.g., func-{suffix}, swa-{suffix}). Prevents accidental creation of duplicate resources.')
 @minLength(1)
 param resourceSuffix string
@@ -69,9 +75,11 @@ var functionIpSecurityRestrictions = concat(functionDebugIpSecurityRestrictions,
 // Build complete CORS origins list, adding Static Web App if provided
 // Include both with and without trailing slash to handle browser Origin header variations
 // This addresses preflight CORS failures when browser sends Origin with trailing slash
-var completeCorsOrigins = !empty(staticWebAppHostname) 
-  ? union(functionCorsAllowedOrigins, ['https://${staticWebAppHostname}', 'https://${staticWebAppHostname}/'])
-  : functionCorsAllowedOrigins
+var completeCorsOrigins = union(
+  functionCorsAllowedOrigins,
+  !empty(staticWebAppHostname) ? ['https://${staticWebAppHostname}', 'https://${staticWebAppHostname}/'] : [],
+  !empty(swaCustomDomain)      ? ['https://${swaCustomDomain}', 'https://${swaCustomDomain}/']           : []
+)
 
 resource storageAccount 'Microsoft.Storage/storageAccounts@2023-01-01' = {
   name: storageAccountName
@@ -226,6 +234,16 @@ resource staticWebAppCustomDomain 'Microsoft.Web/staticSites/customDomains@2022-
   ]
 }
 
+// Custom domain for the marketplace site (e.g., marketplace.devopsjournal.io)
+// Prerequisite: CNAME <subdomain> -> SWA default hostname must exist in DNS before deployment
+resource staticWebAppSiteDomain 'Microsoft.Web/staticSites/customDomains@2022-09-01' = if (!empty(swaCustomDomain)) {
+  name: swaCustomDomain
+  parent: staticWebApp
+  properties: {
+    validationMethod: 'cname-delegation'
+  }
+}
+
 output staticWebAppDefaultHostname string = staticWebApp.properties.defaultHostname
 output functionAppDefaultHostname string = functionApp.properties.defaultHostName
 output functionAppName string = functionApp.name
@@ -256,6 +274,19 @@ resource containerAppsEnvironment 'Microsoft.App/managedEnvironments@2023-05-01'
 
 // --- Container App: MCP Server ---
 
+// Managed TLS certificate for the MCP custom domain.
+// Prerequisites: CNAME <subdomain> -> Container App FQDN and TXT asuid.<subdomain> -> mcpCustomDomainVerificationId
+// must exist in DNS before this cert can be provisioned.
+resource mcpManagedCert 'Microsoft.App/managedEnvironments/managedCertificates@2023-05-01' = if (!empty(mcpCustomDomain)) {
+  name: 'cert-mcp-${uniqueSuffix}'
+  parent: containerAppsEnvironment
+  location: location
+  properties: {
+    subjectName: mcpCustomDomain
+    domainControlValidation: 'CNAME'
+  }
+}
+
 resource mcpContainerApp 'Microsoft.App/containerApps@2023-05-01' = {
   name: containerAppName
   location: location
@@ -275,6 +306,13 @@ resource mcpContainerApp 'Microsoft.App/containerApps@2023-05-01' = {
         external: true
         targetPort: 3000
         transport: 'http'
+        customDomains: !empty(mcpCustomDomain) ? [
+          {
+            name: mcpCustomDomain
+            certificateId: mcpManagedCert.id
+            bindingType: 'SniEnabled'
+          }
+        ] : []
       }
     }
     template: {
@@ -316,3 +354,4 @@ resource acrPullRoleAssignment 'Microsoft.Authorization/roleAssignments@2022-04-
 
 output containerRegistryLoginServer string = containerRegistry.properties.loginServer
 output mcpServerFqdn string = mcpContainerApp.properties.configuration.ingress.fqdn
+output mcpCustomDomainVerificationId string = mcpContainerApp.properties.customDomainVerificationId


### PR DESCRIPTION
## Summary

Adds Bicep + workflow support for two custom domains on `devopsjournal.io`:

| Domain | Target |
|---|---|
| `marketplace.devopsjournal.io` | Azure Static Web App |
| `actions-mcp.devopsjournal.io` | Azure Container App (MCP server) |

## Changes

### `IAC/main.bicep`
- New `swaCustomDomain` param — creates a SWA custom domain resource using CNAME delegation
- New `mcpCustomDomain` param — creates a managed TLS certificate in the Container Apps environment and binds it to the Container App ingress
- CORS origins updated to include `swaCustomDomain` when set
- New output `mcpCustomDomainVerificationId` for use in DNS TXT record setup

### `.github/workflows/deploy-infra.yml`
- Reads `SWA_CUSTOM_DOMAIN` and `MCP_CUSTOM_DOMAIN` repo vars
- Passes them as Bicep parameters when set

### `IAC/README.md`
- Documents the full two-step setup process for both domains

## DNS Setup (to do before deploying with custom domains)

**`marketplace.devopsjournal.io`:**
```
CNAME  marketplace  →  salmon-wave-020c7d703.2.azurestaticapps.net
```
Then set repo var `SWA_CUSTOM_DOMAIN=marketplace.devopsjournal.io` and run the deploy workflow.

**`actions-mcp.devopsjournal.io`:**
```
CNAME  actions-mcp  →  ca-mcp-wsg6po7n4p5dg.ashyplant-207692d4.westeurope.azurecontainerapps.io
TXT    asuid.actions-mcp  →  <mcpCustomDomainVerificationId output from first deploy>
```
Then set repo var `MCP_CUSTOM_DOMAIN=actions-mcp.devopsjournal.io` and run the deploy workflow again.