### PR TITLE
fix: resolve actionlint/shellcheck warnings in deploy workflows

### DIFF
--- a/.github/workflows/deploy-backend.yml
+++ b/.github/workflows/deploy-backend.yml
@@ -83,12 +83,16 @@ jobs:
             exit 1
           fi
 
-          echo "FUNCTION_APP_NAME=$appName" >> "$GITHUB_ENV"
-          echo "FUNCTION_APP_HOSTNAME=$hostName" >> "$GITHUB_ENV"
-          echo "API_URL=https://$hostName/api" >> "$GITHUB_ENV"
+          {
+            echo "FUNCTION_APP_NAME=$appName"
+            echo "FUNCTION_APP_HOSTNAME=$hostName"
+            echo "API_URL=https://$hostName/api"
+          } >> "$GITHUB_ENV"
 
-          echo "function_app_name=$appName" >> "$GITHUB_OUTPUT"
-          echo "function_app_hostname=$hostName" >> "$GITHUB_OUTPUT"
+          {
+            echo "function_app_name=$appName"
+            echo "function_app_hostname=$hostName"
+          } >> "$GITHUB_OUTPUT"
           echo "Resolved Function App: $appName ($hostName)"
 
       - name: Package function app

--- a/.github/workflows/deploy-frontend.yml
+++ b/.github/workflows/deploy-frontend.yml
@@ -144,7 +144,7 @@ jobs:
           swaName="${{ needs.resolve.outputs.swa_name }}"
           token=$(az staticwebapp secrets list --name "$swaName" --query "properties.apiKey" -o tsv)
           echo "::add-mask::$token"
-          echo "deployment_token=$token" >> $GITHUB_OUTPUT
+          echo "deployment_token=$token" >> "$GITHUB_OUTPUT"
 
       - name: Copy staticwebapp.config.json into dist
         run: |
@@ -216,7 +216,7 @@ jobs:
           echo "Runner public IP: $runnerIp"
 
           ruleName="AllowGitHubRunnerE2E-${GITHUB_RUN_ID}"
-          echo "ALLOW_RULE_NAME=$ruleName" >> $GITHUB_ENV
+          echo "ALLOW_RULE_NAME=$ruleName" >> "$GITHUB_ENV"
 
           az functionapp config access-restriction add \
             --resource-group "${{ vars.AZURE_RESOURCE_GROUP }}" \
@@ -228,7 +228,7 @@ jobs:
             --description "Temporary allow for GitHub Actions E2E tests"
 
           sleep 10
-          echo "RUNNER_PUBLIC_IP=$runnerIp" >> $GITHUB_ENV
+          echo "RUNNER_PUBLIC_IP=$runnerIp" >> "$GITHUB_ENV"
 
       - name: Diagnose API access + CORS (runner + browser origin)
         env:

--- a/.github/workflows/deploy-infra.yml
+++ b/.github/workflows/deploy-infra.yml
@@ -97,10 +97,12 @@ jobs:
           swaName="swa-${{ vars.RESOURCE_SUFFIX }}"
           if ! az staticwebapp show --resource-group "${{ vars.AZURE_RESOURCE_GROUP }}" --name "$swaName" >/dev/null 2>&1; then
             echo "::warning::Static Web App $swaName not found (first deploy?); CORS and IP restrictions will not be configured."
-            echo "swa_name=$swaName" >> $GITHUB_OUTPUT
-            echo "swa_hostname=" >> $GITHUB_OUTPUT
-            echo "outbound_ips=" >> $GITHUB_OUTPUT
-            echo "outbound_ips_json=[]" >> $GITHUB_OUTPUT
+            {
+              echo "swa_name=$swaName"
+              echo "swa_hostname="
+              echo "outbound_ips="
+              echo "outbound_ips_json=[]"
+            } >> "$GITHUB_OUTPUT"
             exit 0
           fi
 
@@ -127,10 +129,12 @@ jobs:
             outboundIpsJson=$(echo "$outboundIps" | jq -R 'split(",")')
           fi
 
-          echo "swa_name=$swaName" >> $GITHUB_OUTPUT
-          echo "swa_hostname=$swaHostname" >> $GITHUB_OUTPUT
-          echo "outbound_ips=$outboundIps" >> $GITHUB_OUTPUT
-          echo "outbound_ips_json=$outboundIpsJson" >> $GITHUB_OUTPUT
+          {
+            echo "swa_name=$swaName"
+            echo "swa_hostname=$swaHostname"
+            echo "outbound_ips=$outboundIps"
+            echo "outbound_ips_json=$outboundIpsJson"
+          } >> "$GITHUB_OUTPUT"
 
       - name: Prepare deployment parameters file
         env:

--- a/.github/workflows/deploy-mcp-server.yml
+++ b/.github/workflows/deploy-mcp-server.yml
@@ -79,7 +79,7 @@ jobs:
               echo "Health check passed"
               break
             fi
-            if [ $i -eq 10 ]; then
+            if [ "$i" -eq 10 ]; then
               echo "::error::Container failed to become healthy"
               docker logs "$container_id"
               exit 1

--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -68,7 +68,7 @@ jobs:
           fi
           # Remove 'v' prefix if present
           VERSION="${TAG#v}"
-          echo "version=$VERSION" >> $GITHUB_OUTPUT
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
           echo "Publishing version: $VERSION"
 
       - name: Update package version


### PR DESCRIPTION
## Summary

Fixes pre-existing shellcheck warnings reported by the \Lint GitHub Actions workflows\ check (actionlint).

### Changes

**\.github/workflows/deploy-backend.yml\**
- SC2129: Grouped consecutive \cho\ redirects to \\\ and \\\ using \{ } >> file\ syntax instead of individual redirects per line

**\.github/workflows/deploy-frontend.yml\**
- SC2086 (3 occurrences): Double-quoted \\\ and \\\ in redirect targets to prevent globbing and word splitting

No functional behaviour is changed — these are purely style/safety fixes to silence shellcheck.