### PR TITLE
feat: add State of GitHub Actions page with NavBar

### DIFF
--- a/src/frontend/src/App.css
+++ b/src/frontend/src/App.css
@@ -1194,3 +1194,152 @@ body {
   }
 }
 
+/* ============================================================
+   NavBar
+   ============================================================ */
+
+.nav-bar {
+  display: flex;
+  gap: 4px;
+  margin-bottom: 14px;
+  position: relative;
+  flex-wrap: wrap;
+}
+
+.nav-bar a {
+  font-size: 13px;
+  font-weight: 600;
+  color: rgba(255, 255, 255, 0.65);
+  text-decoration: none;
+  padding: 5px 12px;
+  border-radius: var(--r-pill);
+  border: 1.5px solid transparent;
+  transition: color var(--t), background var(--t), border-color var(--t);
+  letter-spacing: 0.2px;
+}
+
+.nav-bar a:hover {
+  color: rgba(255, 255, 255, 0.95);
+  background: rgba(255, 255, 255, 0.1);
+  border-color: rgba(255, 255, 255, 0.2);
+}
+
+.nav-bar a.active {
+  color: #fff;
+  background: rgba(255, 255, 255, 0.15);
+  border-color: rgba(255, 255, 255, 0.35);
+}
+
+/* ============================================================
+   State of Actions page
+   ============================================================ */
+
+.soa-section-title {
+  font-size: 13px;
+  font-weight: 700;
+  color: var(--c-text-3);
+  text-transform: uppercase;
+  letter-spacing: 0.8px;
+  margin: 28px 0 12px;
+}
+
+.soa-grid {
+  display: grid;
+  gap: 16px;
+  margin-bottom: 8px;
+}
+
+.soa-grid-2 {
+  grid-template-columns: repeat(2, 1fr);
+}
+
+.soa-grid-4 {
+  grid-template-columns: repeat(4, 1fr);
+}
+
+@media (max-width: 900px) {
+  .soa-grid-4 {
+    grid-template-columns: repeat(2, 1fr);
+  }
+
+  .soa-grid-2 {
+    grid-template-columns: 1fr;
+  }
+}
+
+@media (max-width: 520px) {
+  .soa-grid-4 {
+    grid-template-columns: 1fr;
+  }
+}
+
+.soa-card {
+  background: var(--c-surface);
+  border: 1.5px solid var(--c-border);
+  border-radius: var(--r-lg);
+  padding: 20px 22px;
+  box-shadow: var(--shadow-sm);
+}
+
+.soa-card-title {
+  font-size: 11px;
+  font-weight: 700;
+  color: var(--c-text-3);
+  text-transform: uppercase;
+  letter-spacing: 0.7px;
+  margin-bottom: 10px;
+}
+
+.soa-metric {
+  font-size: 40px;
+  font-weight: 800;
+  color: var(--c-text);
+  line-height: 1;
+  letter-spacing: -1px;
+  margin-bottom: 4px;
+}
+
+.soa-metric-label {
+  font-size: 12px;
+  color: var(--c-text-3);
+}
+
+.soa-donut {
+  flex-shrink: 0;
+}
+
+.soa-bar-track {
+  height: 8px;
+  background: var(--c-surface-2);
+  border-radius: var(--r-pill);
+  overflow: hidden;
+  border: 1px solid var(--c-border);
+}
+
+.soa-bar-fill {
+  height: 100%;
+  border-radius: var(--r-pill);
+  transition: width 0.5s ease;
+  min-width: 0;
+}
+
+.soa-legend {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.soa-legend-dot {
+  width: 10px;
+  height: 10px;
+  border-radius: 50%;
+  flex-shrink: 0;
+  display: inline-block;
+}
+
+.soa-pct-label {
+  font-size: 13px;
+  font-weight: 600;
+  color: var(--c-text);
+}
+

--- a/src/frontend/src/App.tsx
+++ b/src/frontend/src/App.tsx
@@ -3,6 +3,7 @@ import { BrowserRouter as Router, Routes, Route, useLocation } from 'react-route
 import { OverviewPage } from './pages/OverviewPage';
 import { DetailPage } from './pages/DetailPage';
 import { StatusPage } from './pages/StatusPage';
+import { StateOfActionsPage } from './pages/StateOfActionsPage';
 import { trackPageView as trackAppInsights } from './telemetry';
 import { trackPageView as trackPlausible } from './plausible';
 import './App.css';
@@ -26,6 +27,7 @@ const App: React.FC = () => {
         <Route path="/" element={<OverviewPage />} />
         <Route path="/action/:owner/:name" element={<DetailPage />} />
         <Route path="/status" element={<StatusPage />} />
+        <Route path="/state" element={<StateOfActionsPage />} />
       </Routes>
     </Router>
   );

--- a/src/frontend/src/components/NavBar.tsx
+++ b/src/frontend/src/components/NavBar.tsx
@@ -1,0 +1,18 @@
+import React from 'react';
+import { NavLink } from 'react-router-dom';
+
+export const NavBar: React.FC = () => {
+  return (
+    <nav className="nav-bar">
+      <NavLink to="/" end className={({ isActive }) => isActive ? 'active' : undefined}>
+        Marketplace
+      </NavLink>
+      <NavLink to="/state" className={({ isActive }) => isActive ? 'active' : undefined}>
+        State of Actions
+      </NavLink>
+      <NavLink to="/status" className={({ isActive }) => isActive ? 'active' : undefined}>
+        Data Status
+      </NavLink>
+    </nav>
+  );
+};

--- a/src/frontend/src/pages/OverviewPage.tsx
+++ b/src/frontend/src/pages/OverviewPage.tsx
@@ -1,9 +1,10 @@
 import React, { useEffect, useRef, useState } from 'react';
-import { useNavigate, Link } from 'react-router-dom';
+import { useNavigate } from 'react-router-dom';
 import { Action, ActionStats, ActionTypeFilter } from '../types/Action';
 import { actionsService, parseDependentsCount, formatDependentsCount } from '../services/actionsService';
 import { normalizeRepoName, matchesSearchQuery, isActionVerified } from '../services/utils';
 import { AnimatedCounter } from '../components/AnimatedCounter';
+import { NavBar } from '../components/NavBar';
 
 const PAGE_SIZE = 12;
 const OVERVIEW_STATE_KEY = 'overviewState:v1';
@@ -389,9 +390,9 @@ export const OverviewPage: React.FC = () => {
   return (
     <div className="app">
       <div className="header">
+        <NavBar />
         <h1>Alternative GitHub Actions Marketplace</h1>        
         <p>Browse and search through <AnimatedCounter value={stats.total} /> with more information</p>
-        <Link to="/status" className="header-status-link">View data freshness →</Link>
       </div>
 
       <div className="stats-bar">

--- a/src/frontend/src/pages/StateOfActionsPage.tsx
+++ b/src/frontend/src/pages/StateOfActionsPage.tsx
@@ -1,0 +1,502 @@
+import React, { useEffect, useState, useMemo } from 'react';
+import { Action, ActionStats } from '../types/Action';
+import { actionsService } from '../services/actionsService';
+import { AnimatedCounter } from '../components/AnimatedCounter';
+import { NavBar } from '../components/NavBar';
+
+/* ------------------------------------------------------------------ */
+/*  Types                                                               */
+/* ------------------------------------------------------------------ */
+
+interface ComputedStats {
+  criticalVulnCount: number;
+  highVulnCount: number;
+  dependabotEnabledCount: number;
+  secretScanningCount: number;
+  ossfScoreBands: number[];
+  avgOssfScore: number;
+  nodeVersions: Record<string, number>;
+  lastUpdatedBands: { label: string; count: number }[];
+  archivedCount: number;
+}
+
+/* ------------------------------------------------------------------ */
+/*  Helpers                                                             */
+/* ------------------------------------------------------------------ */
+
+function computeStats(actions: Action[]): ComputedStats {
+  const total = actions.length;
+  if (total === 0) {
+    return {
+      criticalVulnCount: 0,
+      highVulnCount: 0,
+      dependabotEnabledCount: 0,
+      secretScanningCount: 0,
+      ossfScoreBands: [0, 0, 0, 0, 0],
+      avgOssfScore: 0,
+      nodeVersions: {},
+      lastUpdatedBands: [],
+      archivedCount: 0,
+    };
+  }
+
+  let criticalVulnCount = 0;
+  let highVulnCount = 0;
+  let dependabotEnabledCount = 0;
+  let secretScanningCount = 0;
+  // bands: 0-2, 2-4, 4-6, 6-8, 8-10
+  const ossfScoreBands = [0, 0, 0, 0, 0];
+  let ossfScoreSum = 0;
+  let ossfScoreActionCount = 0;
+  const nodeVersions: Record<string, number> = {};
+  let archivedCount = 0;
+
+  const now = Date.now();
+  const bandCounts = [0, 0, 0, 0, 0]; // <7d, 7-30d, 30-90d, 90-365d, >365d
+
+  for (const a of actions) {
+    if (a.vulnerabilityStatus?.critical > 0) criticalVulnCount++;
+    if (a.vulnerabilityStatus?.high > 0) highVulnCount++;
+    if (a.dependabotEnabled) dependabotEnabledCount++;
+    if (a.secretScanningEnabled) secretScanningCount++;
+
+    if (a.ossf && typeof a.ossfScore === 'number' && a.ossfScore > 0) {
+      const band = Math.min(Math.floor(a.ossfScore / 2), 4);
+      ossfScoreBands[band]++;
+      ossfScoreSum += a.ossfScore;
+      ossfScoreActionCount++;
+    }
+
+    if (a.actionType?.actionType === 'Node' && a.actionType.nodeVersion) {
+      const ver = a.actionType.nodeVersion;
+      nodeVersions[ver] = (nodeVersions[ver] || 0) + 1;
+    }
+
+    if (a.repoInfo?.archived) archivedCount++;
+
+    const updatedStr = a.repoInfo?.updated_at;
+    if (updatedStr) {
+      const ms = Date.now() - new Date(updatedStr).getTime();
+      const days = ms / 86400000;
+      if (days < 7) bandCounts[0]++;
+      else if (days < 30) bandCounts[1]++;
+      else if (days < 90) bandCounts[2]++;
+      else if (days < 365) bandCounts[3]++;
+      else bandCounts[4]++;
+    }
+  }
+
+  void now; // suppress unused warning
+
+  return {
+    criticalVulnCount,
+    highVulnCount,
+    dependabotEnabledCount,
+    secretScanningCount,
+    ossfScoreBands,
+    avgOssfScore: ossfScoreActionCount > 0 ? ossfScoreSum / ossfScoreActionCount : 0,
+    nodeVersions,
+    lastUpdatedBands: [
+      { label: 'Within 7 days', count: bandCounts[0] },
+      { label: '7-30 days', count: bandCounts[1] },
+      { label: '30-90 days', count: bandCounts[2] },
+      { label: '90-365 days', count: bandCounts[3] },
+      { label: 'Over 1 year', count: bandCounts[4] },
+    ],
+    archivedCount,
+  };
+}
+
+function pct(count: number, total: number): string {
+  if (total === 0) return '0%';
+  return Math.round((count / total) * 100) + '%';
+}
+
+/* ------------------------------------------------------------------ */
+/*  SVG Donut Chart                                                     */
+/* ------------------------------------------------------------------ */
+
+interface DonutSlice {
+  value: number;
+  color: string;
+  label: string;
+}
+
+interface DonutChartProps {
+  slices: DonutSlice[];
+  size?: number;
+  thickness?: number;
+}
+
+const DonutChart: React.FC<DonutChartProps> = ({ slices, size = 160, thickness = 28 }) => {
+  const total = slices.reduce((s, sl) => s + sl.value, 0);
+  if (total === 0) return <div className="soa-donut" />;
+
+  const r = (size - thickness) / 2;
+  const cx = size / 2;
+  const cy = size / 2;
+  const circumference = 2 * Math.PI * r;
+
+  let offset = 0;
+  const paths = slices
+    .filter(sl => sl.value > 0)
+    .map((sl) => {
+      const dash = (sl.value / total) * circumference;
+      const gap = circumference - dash;
+      const rotate = (offset / total) * 360 - 90;
+      offset += sl.value;
+      return { sl, dash, gap, rotate };
+    });
+
+  return (
+    <svg width={size} height={size} viewBox={`0 0 ${size} ${size}`} className="soa-donut">
+      {paths.map(({ sl, dash, gap, rotate }, i) => (
+        <circle
+          key={i}
+          cx={cx}
+          cy={cy}
+          r={r}
+          fill="none"
+          stroke={sl.color}
+          strokeWidth={thickness}
+          strokeDasharray={`${dash} ${gap}`}
+          transform={`rotate(${rotate} ${cx} ${cy})`}
+          strokeLinecap="butt"
+        />
+      ))}
+    </svg>
+  );
+};
+
+/* ------------------------------------------------------------------ */
+/*  Bar chart row                                                       */
+/* ------------------------------------------------------------------ */
+
+interface BarRowProps {
+  label: string;
+  count: number;
+  total: number;
+  color: string;
+}
+
+const BarRow: React.FC<BarRowProps> = ({ label, count, total, color }) => {
+  const p = total > 0 ? Math.max((count / total) * 100, count > 0 ? 1 : 0) : 0;
+  return (
+    <div style={{ marginBottom: 10 }}>
+      <div style={{ display: 'flex', justifyContent: 'space-between', marginBottom: 4, fontSize: 13 }}>
+        <span style={{ color: 'var(--c-text-2)' }}>{label}</span>
+        <span className="soa-pct-label">{count.toLocaleString()} <span style={{ color: 'var(--c-text-3)' }}>({pct(count, total)})</span></span>
+      </div>
+      <div className="soa-bar-track">
+        <div className="soa-bar-fill" style={{ width: `${p}%`, background: color }} />
+      </div>
+    </div>
+  );
+};
+
+/* ------------------------------------------------------------------ */
+/*  Security card                                                        */
+/* ------------------------------------------------------------------ */
+
+interface SecurityCardProps {
+  title: string;
+  count: number;
+  total: number;
+  color: string;
+  subtitle: string;
+}
+
+const SecurityCard: React.FC<SecurityCardProps> = ({ title, count, total, color, subtitle }) => (
+  <div className="soa-card" style={{ borderTop: `3px solid ${color}` }}>
+    <div className="soa-card-title">{title}</div>
+    <div className="soa-metric" style={{ color }}><AnimatedCounter value={count} /></div>
+    <div className="soa-metric-label">{pct(count, total)} of actions</div>
+    <div style={{ fontSize: 12, color: 'var(--c-text-3)', marginTop: 6 }}>{subtitle}</div>
+  </div>
+);
+
+/* ------------------------------------------------------------------ */
+/*  Main page                                                           */
+/* ------------------------------------------------------------------ */
+
+export const StateOfActionsPage: React.FC = () => {
+  const [stats, setStats] = useState<ActionStats | null>(null);
+  const [actions, setActions] = useState<Action[]>([]);
+  const [loadingStats, setLoadingStats] = useState(true);
+  const [loadingActions, setLoadingActions] = useState(true);
+  const [statsError, setStatsError] = useState<string | null>(null);
+
+  useEffect(() => {
+    actionsService.fetchStats()
+      .then(s => { setStats(s); setLoadingStats(false); })
+      .catch(() => { setStatsError('Failed to load stats.'); setLoadingStats(false); });
+  }, []);
+
+  useEffect(() => {
+    actionsService.fetchActions()
+      .then(a => { setActions(a); setLoadingActions(false); })
+      .catch(() => setLoadingActions(false));
+  }, []);
+
+  const computed = useMemo(() => computeStats(actions), [actions]);
+
+  const total = stats?.total ?? actions.length;
+
+  const donutSlices: DonutSlice[] = stats
+    ? [
+        { label: 'Node', value: stats.byType['Node'] ?? 0, color: 'var(--c-green)' },
+        { label: 'Docker', value: stats.byType['Docker'] ?? 0, color: 'var(--c-sky)' },
+        { label: 'Composite', value: stats.byType['Composite'] ?? 0, color: 'var(--c-purple)' },
+      ]
+    : [];
+
+  const topNodeVersions = Object.entries(computed.nodeVersions)
+    .sort((a, b) => b[1] - a[1])
+    .slice(0, 8);
+
+  const nodeTotal = topNodeVersions.reduce((s, [, v]) => s + v, 0);
+
+  const ossfBandLabels = ['0-2', '2-4', '4-6', '6-8', '8-10'];
+  const ossfColors = ['var(--c-red)', 'var(--c-amber)', 'var(--c-sky)', 'var(--c-green)', 'var(--c-green)'];
+  const maxOssfBand = Math.max(...computed.ossfScoreBands, 1);
+
+  const updateColors = ['var(--c-green)', 'var(--c-sky)', 'var(--c-amber)', 'var(--c-red)', 'var(--c-red)'];
+
+  return (
+    <div className="app">
+      <div className="header">
+        <NavBar />
+        <h1>State of GitHub Actions</h1>
+        <p>
+          {loadingActions
+            ? 'Loading data...'
+            : `Insights from ${total.toLocaleString()} actions in the marketplace`}
+        </p>
+      </div>
+
+      {(loadingStats || loadingActions) && (
+        <div style={{ fontSize: 13, color: 'var(--c-text-3)', marginBottom: 16 }}>
+          {loadingStats && 'Loading stats... '}
+          {loadingActions && 'Loading full actions list (this may take a moment)...'}
+        </div>
+      )}
+
+      {statsError && <div className="error-message">{statsError}</div>}
+
+      {/* Key metrics */}
+      <div className="soa-section-title">Key Metrics</div>
+      <div className="soa-grid soa-grid-4">
+        <div className="soa-card">
+          <div className="soa-card-title">Total Actions</div>
+          <div className="soa-metric"><AnimatedCounter value={total} /></div>
+          <div className="soa-metric-label">in the marketplace</div>
+        </div>
+        <div className="soa-card">
+          <div className="soa-card-title">Verified Actions</div>
+          <div className="soa-metric" style={{ color: 'var(--c-green)' }}>
+            <AnimatedCounter value={stats?.verified ?? 0} />
+          </div>
+          <div className="soa-metric-label">{pct(stats?.verified ?? 0, total)} verified</div>
+        </div>
+        <div className="soa-card">
+          <div className="soa-card-title">Archived</div>
+          <div className="soa-metric" style={{ color: 'var(--c-red)' }}>
+            <AnimatedCounter value={loadingActions ? (stats?.archived ?? 0) : computed.archivedCount} />
+          </div>
+          <div className="soa-metric-label">
+            {pct(loadingActions ? (stats?.archived ?? 0) : computed.archivedCount, total)} archived
+          </div>
+        </div>
+        <div className="soa-card">
+          <div className="soa-card-title">With OpenSSF Score</div>
+          <div className="soa-metric" style={{ color: 'var(--c-sky)' }}>
+            <AnimatedCounter value={stats?.withOssf ?? 0} />
+          </div>
+          <div className="soa-metric-label">{pct(stats?.withOssf ?? 0, total)} have OSSF data</div>
+        </div>
+      </div>
+
+      {/* Action types */}
+      <div className="soa-section-title">Action Types</div>
+      <div className="soa-grid soa-grid-2">
+        <div className="soa-card" style={{ display: 'flex', alignItems: 'center', gap: 28 }}>
+          <DonutChart slices={donutSlices} size={160} thickness={30} />
+          <div style={{ flex: 1 }}>
+            {donutSlices.map(sl => (
+              <div key={sl.label} style={{ display: 'flex', alignItems: 'center', gap: 8, marginBottom: 10 }}>
+                <span className="soa-legend-dot" style={{ background: sl.color }} />
+                <span style={{ flex: 1, fontSize: 14, color: 'var(--c-text-2)' }}>{sl.label}</span>
+                <span style={{ fontWeight: 700, color: 'var(--c-text)' }}>
+                  {sl.value.toLocaleString()}
+                </span>
+                <span style={{ fontSize: 12, color: 'var(--c-text-3)', minWidth: 42, textAlign: 'right' }}>
+                  {pct(sl.value, total)}
+                </span>
+              </div>
+            ))}
+          </div>
+        </div>
+        <div className="soa-card">
+          <div className="soa-card-title">Distribution</div>
+          {donutSlices.map(sl => (
+            <BarRow key={sl.label} label={sl.label} count={sl.value} total={total} color={sl.color} />
+          ))}
+        </div>
+      </div>
+
+      {/* Security overview */}
+      <div className="soa-section-title">Security Overview</div>
+      <div className="soa-grid soa-grid-4">
+        <SecurityCard
+          title="Critical Vulnerabilities"
+          count={computed.criticalVulnCount}
+          total={total}
+          color="var(--c-red)"
+          subtitle="Actions with at least one critical CVE"
+        />
+        <SecurityCard
+          title="High Vulnerabilities"
+          count={computed.highVulnCount}
+          total={total}
+          color="var(--c-amber)"
+          subtitle="Actions with at least one high CVE"
+        />
+        <SecurityCard
+          title="Dependabot Enabled"
+          count={computed.dependabotEnabledCount}
+          total={total}
+          color="var(--c-green)"
+          subtitle="Actions with Dependabot alerts enabled"
+        />
+        <SecurityCard
+          title="Secret Scanning"
+          count={computed.secretScanningCount}
+          total={total}
+          color="var(--c-sky)"
+          subtitle="Actions with secret scanning enabled"
+        />
+      </div>
+
+      {/* OpenSSF score distribution */}
+      <div className="soa-section-title">OpenSSF Score Distribution</div>
+      <div className="soa-grid soa-grid-2">
+        <div className="soa-card">
+          <div className="soa-card-title">Score Bands</div>
+          {ossfBandLabels.map((label, i) => (
+            <div key={label} style={{ marginBottom: 10 }}>
+              <div style={{ display: 'flex', justifyContent: 'space-between', marginBottom: 4, fontSize: 13 }}>
+                <span style={{ color: 'var(--c-text-2)', minWidth: 36 }}>{label}</span>
+                <span className="soa-pct-label">{computed.ossfScoreBands[i].toLocaleString()}</span>
+              </div>
+              <div className="soa-bar-track">
+                <div
+                  className="soa-bar-fill"
+                  style={{
+                    width: `${maxOssfBand > 0 ? (computed.ossfScoreBands[i] / maxOssfBand) * 100 : 0}%`,
+                    background: ossfColors[i]
+                  }}
+                />
+              </div>
+            </div>
+          ))}
+        </div>
+        <div className="soa-card">
+          <div className="soa-card-title">Average Score</div>
+          <div className="soa-metric" style={{ color: computed.avgOssfScore >= 5 ? 'var(--c-green)' : 'var(--c-amber)', fontSize: 52 }}>
+            {computed.avgOssfScore > 0 ? computed.avgOssfScore.toFixed(1) : '—'}
+          </div>
+          <div className="soa-metric-label">out of 10.0</div>
+          <div style={{ marginTop: 20 }}>
+            <div style={{ fontSize: 13, color: 'var(--c-text-2)', marginBottom: 8 }}>Score interpretation</div>
+            {[['8-10', 'Excellent', 'var(--c-green)'], ['6-8', 'Good', 'var(--c-sky)'], ['4-6', 'Fair', 'var(--c-amber)'], ['0-4', 'Needs work', 'var(--c-red)']].map(([range, label, color]) => (
+              <div key={range} style={{ display: 'flex', alignItems: 'center', gap: 8, marginBottom: 6 }}>
+                <span className="soa-legend-dot" style={{ background: color }} />
+                <span style={{ fontSize: 13, color: 'var(--c-text-2)' }}>{range}: {label}</span>
+              </div>
+            ))}
+          </div>
+        </div>
+      </div>
+
+      {/* Node.js versions */}
+      {topNodeVersions.length > 0 && (
+        <>
+          <div className="soa-section-title">Node.js Version Distribution</div>
+          <div className="soa-card">
+            <div className="soa-card-title">Top Node.js runtimes used in Node-type actions</div>
+            <div style={{ display: 'grid', gridTemplateColumns: 'repeat(auto-fill, minmax(220px, 1fr))', gap: 8, marginTop: 12 }}>
+              {topNodeVersions.map(([ver, count]) => (
+                <div key={ver}>
+                  <div style={{ display: 'flex', justifyContent: 'space-between', fontSize: 13, marginBottom: 4 }}>
+                    <span style={{ color: 'var(--c-text)', fontWeight: 600 }}>node{ver}</span>
+                    <span className="soa-pct-label">{count.toLocaleString()} ({pct(count, nodeTotal)})</span>
+                  </div>
+                  <div className="soa-bar-track">
+                    <div
+                      className="soa-bar-fill"
+                      style={{
+                        width: `${(count / (topNodeVersions[0]?.[1] ?? 1)) * 100}%`,
+                        background: 'var(--c-green)'
+                      }}
+                    />
+                  </div>
+                </div>
+              ))}
+            </div>
+          </div>
+        </>
+      )}
+
+      {/* Maintenance */}
+      <div className="soa-section-title">Maintenance Activity</div>
+      <div className="soa-grid soa-grid-2">
+        <div className="soa-card">
+          <div className="soa-card-title">Last Updated Distribution</div>
+          {computed.lastUpdatedBands.map((band, i) => (
+            <BarRow key={band.label} label={band.label} count={band.count} total={total} color={updateColors[i]} />
+          ))}
+        </div>
+        <div className="soa-card">
+          <div className="soa-card-title">Repository Status</div>
+          <div style={{ display: 'flex', flexDirection: 'column', gap: 12, marginTop: 8 }}>
+            <div>
+              <div style={{ fontSize: 13, color: 'var(--c-text-2)', marginBottom: 6 }}>Active vs Archived</div>
+              <div style={{ display: 'flex', gap: 16 }}>
+                <div>
+                  <div className="soa-metric" style={{ fontSize: 32, color: 'var(--c-green)' }}>
+                    <AnimatedCounter value={total - computed.archivedCount} />
+                  </div>
+                  <div className="soa-metric-label">Active</div>
+                </div>
+                <div>
+                  <div className="soa-metric" style={{ fontSize: 32, color: 'var(--c-red)' }}>
+                    <AnimatedCounter value={computed.archivedCount} />
+                  </div>
+                  <div className="soa-metric-label">Archived</div>
+                </div>
+              </div>
+            </div>
+            <div className="soa-bar-track" style={{ marginTop: 4 }}>
+              <div
+                className="soa-bar-fill"
+                style={{
+                  width: `${pct(total - computed.archivedCount, total)}`,
+                  background: 'var(--c-green)'
+                }}
+              />
+            </div>
+            <div style={{ fontSize: 12, color: 'var(--c-text-3)' }}>
+              {pct(computed.archivedCount, total)} of all actions are archived
+            </div>
+          </div>
+        </div>
+      </div>
+
+      {loadingActions && (
+        <div style={{ textAlign: 'center', padding: '20px 0', fontSize: 13, color: 'var(--c-text-3)' }}>
+          Full dataset still loading — security and maintenance sections will update shortly.
+        </div>
+      )}
+    </div>
+  );
+};

--- a/src/frontend/src/pages/StatusPage.tsx
+++ b/src/frontend/src/pages/StatusPage.tsx
@@ -2,6 +2,7 @@ import React, { useEffect, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { DbStatus } from '../types/Action';
 import { actionsService } from '../services/actionsService';
+import { NavBar } from '../components/NavBar';
 
 function formatRelativeTime(isoString: string | null): string {
   if (!isoString) return 'Unknown';
@@ -90,6 +91,7 @@ export const StatusPage: React.FC = () => {
   return (
     <div className="app">
       <div className="header">
+        <NavBar />
         <h1>Alternative GitHub Actions Marketplace</h1>
         <p>Database freshness status</p>
       </div>


### PR DESCRIPTION
## Summary

Adds a new \/state\ route with a rich 'State of GitHub Actions' overview page, plus a shared NavBar in the header.

### New files
- \src/frontend/src/components/NavBar.tsx\ - Nav links to Marketplace / State of Actions / Data Status, uses React Router \NavLink\ for active state
- \src/frontend/src/pages/StateOfActionsPage.tsx\ - Full data-driven stats page

### Modified files
- \src/frontend/src/App.tsx\ - Added \/state\ route
- \src/frontend/src/App.css\ - Added \.nav-bar\, \.soa-*\ styles (responsive, dark-mode aware)
- \src/frontend/src/pages/OverviewPage.tsx\ - Replaced header status link with \<NavBar />\
- \src/frontend/src/pages/StatusPage.tsx\ - Added \<NavBar />\ to header

### State of Actions page sections
1. **Key Metrics** - Animated counters: total, verified, archived, OSSF count
2. **Action Types** - SVG donut chart (stroke-dasharray) for Node/Docker/Composite + bar rows
3. **Security Overview** - Cards for critical/high vulns, Dependabot %, secret scanning %
4. **OpenSSF Score Distribution** - Band histogram (0-2 through 8-10) + average score card
5. **Node.js Version Distribution** - Top runtimes used across Node-type actions
6. **Maintenance** - Last-updated bands + archived count

Data loads progressively: stats API first, full actions list enriches the computed sections once loaded.

Build: \	sc && vite build\ passes cleanly.