### PR TITLE
fix: README 404 on detail page

### DIFF
--- a/.github/workflows/deploy-app.yml
+++ b/.github/workflows/deploy-app.yml
@@ -523,6 +523,12 @@ jobs:
         working-directory: src/backend
         run: node -e "require('./examples/list-actions.js').statsExample()"
 
+      - name: Backend smoke test via client (readme)
+        env:
+          API_URL: ${{ needs.resolve.outputs.api_base_url }}
+        working-directory: src/backend
+        run: node examples/fetch-readme.js actions actions_checkout
+
       - name: Install frontend deps
         run: npm ci
         working-directory: src/frontend

--- a/.github/workflows/deploy-infra.yml
+++ b/.github/workflows/deploy-infra.yml
@@ -243,6 +243,30 @@ jobs:
           fi
           echo "Resource names validated: $DEPLOYED_FUNC_NAME matches expected suffix."
 
+      - name: Configure GitHub token for readme fetching
+        env:
+          GITHUB_TOKEN_FUNC: ${{ secrets.GITHUB_TOKEN_FUNC }}
+        run: |
+          functionAppName="${{ steps.deploy.outputs.functionAppName }}"
+
+          if [ -z "$functionAppName" ]; then
+            echo "::warning::Function app name not available, skipping GITHUB_TOKEN configuration"
+            exit 0
+          fi
+
+          if [ -z "$GITHUB_TOKEN_FUNC" ]; then
+            echo "::warning::GITHUB_TOKEN_FUNC secret not set; readme endpoint will use unauthenticated GitHub API (60 req/hr limit)"
+            exit 0
+          fi
+
+          echo "Configuring GITHUB_TOKEN for $functionAppName..."
+          az functionapp config appsettings set \
+            --resource-group "${{ vars.AZURE_RESOURCE_GROUP }}" \
+            --name "$functionAppName" \
+            --settings "GITHUB_TOKEN=$GITHUB_TOKEN_FUNC" \
+            > /dev/null
+          echo "GITHUB_TOKEN configured successfully"
+
       - name: Configure GitHub App settings
         if: vars.RUNTIME_APP_ID != ''
         env:

--- a/IAC/main.bicep
+++ b/IAC/main.bicep
@@ -102,6 +102,10 @@ resource table 'Microsoft.Storage/storageAccounts/tableServices/tables@2023-01-0
   name: '${storageAccount.name}/default/${tableName}'
 }
 
+resource readmesTable 'Microsoft.Storage/storageAccounts/tableServices/tables@2023-01-01' = {
+  name: '${storageAccount.name}/default/readmes'
+}
+
 resource fileShare 'Microsoft.Storage/storageAccounts/fileServices/shares@2023-01-01' = {
   name: '${storageAccount.name}/default/${fileShareName}'
   properties: {

--- a/src/backend/ActionsReadme/index.js
+++ b/src/backend/ActionsReadme/index.js
@@ -21,7 +21,11 @@ async function fetchReadmeFromGitHub(owner, name, version) {
     throw new Error(`GitHub API error: ${response.status} ${response.statusText}`);
   }
 
-  return await response.text();
+  const html = await response.text();
+  if (!html) {
+    throw new Error(`GitHub API returned empty body for ${owner}/${repoName}@${ref}`);
+  }
+  return html;
 }
 
 async function getRepoUpdatedAt(owner, name) {

--- a/src/backend/lib/githubAuth.js
+++ b/src/backend/lib/githubAuth.js
@@ -6,7 +6,7 @@ const { createAppAuth } = require('@octokit/auth-app');
  */
 async function getGitHubAuthHeaders() {
   const headers = {
-    'Accept': 'application/vnd.github.v3.html',
+    'Accept': 'application/vnd.github.html+json',
     'User-Agent': 'Alternative-GitHub-Actions-Marketplace'
   };
 

--- a/src/backend/tests/githubAuth.test.js
+++ b/src/backend/tests/githubAuth.test.js
@@ -28,7 +28,7 @@ describe('githubAuth', () => {
       const headers = await getGitHubAuthHeaders();
       
       expect(headers).toEqual({
-        'Accept': 'application/vnd.github.v3.html',
+        'Accept': 'application/vnd.github.html+json',
         'User-Agent': 'Alternative-GitHub-Actions-Marketplace'
       });
       expect(headers.Authorization).toBeUndefined();


### PR DESCRIPTION
## Problem
The README section on action detail pages always shows a 404 error.

## Root Cause
The function was using the legacy \Accept: application/vnd.github.v3.html\ header. GitHub's API returns 404 for unauthenticated requests with this header from Azure datacenter IPs.

## Changes
- **\githubAuth.js\**: Switch Accept header to \pplication/vnd.github.html+json\ (current API format)
- **\ActionsReadme/index.js\**: Guard against empty response body
- **\main.bicep\**: Create \eadmes\ table so README caching works in production
- **\deploy-infra.yml\**: New step to configure \GITHUB_TOKEN\ app setting from \GITHUB_TOKEN_FUNC\ secret (5000 req/hr vs 60 unauthenticated)
- **\deploy-app.yml\**: Add readme smoke test to catch regressions after each deploy

## Next Steps After Merge
1. Add \GITHUB_TOKEN_FUNC\ as a repository secret (PAT with \public_repo\ or \contents: read\ scope)
2. Re-run \deploy-infra\ to create the \eadmes\ table and set the token
3. Re-run \deploy-backend\ to deploy the Accept header fix (or it deploys automatically on merge)