### PR TITLE
fix: use PAT instead of GitHub App token for readme fetching

### DIFF
--- a/src/backend/ActionsReadme/index.js
+++ b/src/backend/ActionsReadme/index.js
@@ -1,5 +1,5 @@
 const { withCorsHeaders } = require('../lib/cors');
-const { getGitHubAuthHeaders } = require('../lib/githubAuth');
+const { getPublicReadHeaders } = require('../lib/githubAuth');
 const { getCachedReadme, cacheReadme, isCacheValid } = require('../lib/readmeCache');
 const { getActionEntity } = require('../lib/tableStorage');
 const { ActionRecord } = require('../lib/actionRecord');
@@ -10,7 +10,7 @@ async function fetchReadmeFromGitHub(owner, name, version) {
   const repoName = extractRepoName(owner, name);
   const url = `https://api.github.com/repos/${owner}/${repoName}/readme?ref=${ref}`;
   
-  const headers = await getGitHubAuthHeaders();
+  const headers = await getPublicReadHeaders();
 
   const response = await fetch(url, { headers });
   

--- a/src/backend/lib/githubAuth.js
+++ b/src/backend/lib/githubAuth.js
@@ -36,6 +36,27 @@ async function getGitHubAuthHeaders() {
   return headers;
 }
 
+/**
+ * Creates GitHub authentication headers for reading public content.
+ * Uses only a Personal Access Token (never a GitHub App installation token).
+ * GitHub App installation tokens are scoped to specific repos/orgs; using one
+ * outside its installation scope causes GitHub to return 404 even for public repos.
+ * @returns {Promise<Object>} Headers object with optional Authorization
+ */
+async function getPublicReadHeaders() {
+  const headers = {
+    'Accept': 'application/vnd.github.html+json',
+    'User-Agent': 'Alternative-GitHub-Actions-Marketplace'
+  };
+
+  if (process.env.GITHUB_TOKEN) {
+    headers['Authorization'] = `Bearer ${process.env.GITHUB_TOKEN}`;
+  }
+
+  return headers;
+}
+
 module.exports = {
-  getGitHubAuthHeaders
+  getGitHubAuthHeaders,
+  getPublicReadHeaders
 };

--- a/src/backend/tests/actionsReadme.test.js
+++ b/src/backend/tests/actionsReadme.test.js
@@ -58,7 +58,7 @@ describe('actionsReadme function', () => {
     }));
 
     jest.mock('../lib/githubAuth', () => ({
-      getGitHubAuthHeaders: mockGetGitHubAuthHeaders
+      getPublicReadHeaders: mockGetGitHubAuthHeaders
     }));
 
     global.fetch = jest.fn();

--- a/src/backend/tests/githubAuth.test.js
+++ b/src/backend/tests/githubAuth.test.js
@@ -1,4 +1,4 @@
-const { getGitHubAuthHeaders } = require('../lib/githubAuth');
+const { getGitHubAuthHeaders, getPublicReadHeaders } = require('../lib/githubAuth');
 
 // Mock the @octokit/auth-app module
 jest.mock('@octokit/auth-app', () => ({
@@ -97,6 +97,55 @@ describe('githubAuth', () => {
       const headers = await getGitHubAuthHeaders();
 
       expect(headers.Authorization).toBe('Bearer ghs_app_token');
+    });
+  });
+
+  describe('getPublicReadHeaders', () => {
+    it('should return basic headers when no auth is configured', async () => {
+      const headers = await getPublicReadHeaders();
+
+      expect(headers).toEqual({
+        'Accept': 'application/vnd.github.html+json',
+        'User-Agent': 'Alternative-GitHub-Actions-Marketplace'
+      });
+      expect(headers.Authorization).toBeUndefined();
+    });
+
+    it('should use PAT when GITHUB_TOKEN is set', async () => {
+      process.env.GITHUB_TOKEN = 'ghp_test_token';
+
+      const headers = await getPublicReadHeaders();
+
+      expect(headers.Authorization).toBe('Bearer ghp_test_token');
+    });
+
+    it('should not use GitHub App even when App credentials are set', async () => {
+      process.env.GITHUB_APP_ID = '12345';
+      process.env.GITHUB_APP_PRIVATE_KEY = 'fake-private-key';
+      process.env.GITHUB_APP_INSTALLATION_ID = '67890';
+
+      const mockAuth = jest.fn().mockResolvedValue({ token: 'ghs_app_token' });
+      createAppAuth.mockReturnValue(mockAuth);
+
+      const headers = await getPublicReadHeaders();
+
+      expect(createAppAuth).not.toHaveBeenCalled();
+      expect(headers.Authorization).toBeUndefined();
+    });
+
+    it('should use PAT over GitHub App when both are configured', async () => {
+      process.env.GITHUB_APP_ID = '12345';
+      process.env.GITHUB_APP_PRIVATE_KEY = 'fake-private-key';
+      process.env.GITHUB_APP_INSTALLATION_ID = '67890';
+      process.env.GITHUB_TOKEN = 'ghp_token';
+
+      const mockAuth = jest.fn().mockResolvedValue({ token: 'ghs_app_token' });
+      createAppAuth.mockReturnValue(mockAuth);
+
+      const headers = await getPublicReadHeaders();
+
+      expect(createAppAuth).not.toHaveBeenCalled();
+      expect(headers.Authorization).toBe('Bearer ghp_token');
     });
   });
 });


### PR DESCRIPTION
## Problem

The readme endpoint (`/api/actions/{owner}/{name}/readme`) was consistently returning `{"error": "README not found."}` for all actions, including `step-security/harden-runner`, `actions/checkout`, etc.

## Root Cause

The `ActionsReadme` function was using `getGitHubAuthHeaders()` which prefers GitHub App installation tokens. Installation tokens are **scoped to specific repos/orgs** within the installation. When the token is used to access public repos outside the installation scope (e.g. `actions/checkout`, `step-security/harden-runner`), GitHub returns **404** (not 403) to avoid leaking resource existence — causing our code to interpret it as "README not found."

## Fix

Added `getPublicReadHeaders()` to `githubAuth.js` that uses only `GITHUB_TOKEN` (PAT) or unauthenticated access — never a GitHub App installation token. The readme endpoint now uses this function instead.

- GitHub App installation tokens remain for write/admin operations where they're appropriate
- README fetching uses PAT or unauthenticated (60 req/hr limit) which can access any public repo
- All 181 tests pass