### PR TITLE
High-impact optimizations: #169, #175, #170, #167

### DIFF
--- a/src/backend/ActionsStats/index.js
+++ b/src/backend/ActionsStats/index.js
@@ -1,5 +1,48 @@
 const { getTableClient } = require('../lib/tableStorage');
 const { withCorsHeaders } = require('../lib/cors');
+const { readCache, writeCache } = require('../lib/statsCache');
+
+async function computeStats(tableClient) {
+  let total = 0;
+  const byType = {};
+  let verified = 0;
+  let archived = 0;
+  let withOssf = 0;
+
+  for await (const entity of tableClient.listEntities()) {
+    try {
+      const payload = typeof entity.PayloadJson === 'string'
+        ? JSON.parse(entity.PayloadJson)
+        : (entity.PayloadJson || {});
+
+      // Only count entities that we can successfully parse and inspect.
+      total += 1;
+
+      const type = payload.actionType && payload.actionType.actionType;
+      if (type) {
+        byType[type] = (byType[type] || 0) + 1;
+      }
+
+      if (payload.verified === true) {
+        verified += 1;
+      }
+
+      if (payload.repoInfo && payload.repoInfo.archived === true) {
+        archived += 1;
+      }
+
+      const rawScore = payload.openssf_score ?? payload.ossfScore ?? payload.ossf_score ?? null;
+      const hasOssf = payload.ossf === true || (rawScore !== null && rawScore !== undefined);
+      if (hasOssf) {
+        withOssf += 1;
+      }
+    } catch (_parseErr) {
+      // skip malformed payloads entirely (don't include in totals)
+    }
+  }
+
+  return { total, byType, verified, archived, withOssf };
+}
 
 module.exports = async function actionsStats(context, req) {
   if (req.method === 'OPTIONS') {
@@ -21,64 +64,46 @@ module.exports = async function actionsStats(context, req) {
 
   const tableClient = getTableClient();
   const tableUrl = tableClient && tableClient.url ? tableClient.url.split('?')[0] : 'unknown';
-
-  let total = 0;
-  const byType = {};
-  let verified = 0;
-  let archived = 0;
-  let withOssf = 0;
+  const forceRefresh = req.query && req.query.refresh === 'true';
 
   try {
-    for await (const entity of tableClient.listEntities()) {
-      try {
-        const payload = typeof entity.PayloadJson === 'string'
-          ? JSON.parse(entity.PayloadJson)
-          : (entity.PayloadJson || {});
+    let stats;
+    let fromCache = false;
 
-        // Only count entities that we can successfully parse and inspect.
-        total += 1;
-
-        const type = payload.actionType && payload.actionType.actionType;
-        if (type) {
-          byType[type] = (byType[type] || 0) + 1;
-        }
-
-        if (payload.verified === true) {
-          verified += 1;
-        }
-
-        if (payload.repoInfo && payload.repoInfo.archived === true) {
-          archived += 1;
-        }
-
-        const rawScore = payload.openssf_score ?? payload.ossfScore ?? payload.ossf_score ?? null;
-        const hasOssf = payload.ossf === true || (rawScore !== null && rawScore !== undefined);
-        if (hasOssf) {
-          withOssf += 1;
-        }
-      } catch (parseErr) {
-        // skip malformed payloads entirely (don't include in totals)
+    if (!forceRefresh) {
+      const cached = await readCache(tableClient);
+      if (cached && cached.data && cached.data.stats) {
+        stats = cached.data.stats;
+        fromCache = true;
       }
     }
 
-    context.log(`ActionsStats: total=${total}, verified=${verified}, archived=${archived}, withOssf=${withOssf}, table=${tableUrl}`);
+    if (!stats) {
+      stats = await computeStats(tableClient);
+      // Write merged cache (preserve existing status data if present)
+      const existing = await readCache(tableClient).catch(() => null);
+      const existingData = existing && existing.data ? existing.data : {};
+      await writeCache(tableClient, { ...existingData, stats });
+    }
+
+    const { total, byType, verified, archived, withOssf } = stats;
+    context.log(`ActionsStats: total=${total}, verified=${verified}, archived=${archived}, withOssf=${withOssf}, table=${tableUrl}, fromCache=${fromCache}`);
 
     const payload = { total, byType, verified, archived, withOssf };
 
     context.res = {
       status: 200,
       isRaw: true,
-      headers: {
+      headers: withCorsHeaders(req, {
         'X-Actions-Count': total,
         'X-Verified-Count': verified,
         'X-Archived-Count': archived,
         'X-Ossf-Count': withOssf,
         'X-Table-Endpoint': tableUrl,
         'Content-Type': 'application/json'
-      },
+      }),
       body: JSON.stringify(payload)
     };
-    context.res.headers = withCorsHeaders(req, context.res.headers);
   } catch (error) {
     context.log.error('Error computing stats:', error);
     context.res = {

--- a/src/backend/ActionsStatus/index.js
+++ b/src/backend/ActionsStatus/index.js
@@ -1,5 +1,6 @@
 const { getTableClient } = require('../lib/tableStorage');
 const { withCorsHeaders } = require('../lib/cors');
+const { readCache, writeCache } = require('../lib/statsCache');
 
 /**
  * Returns data-freshness metrics for the actions database.
@@ -10,6 +11,61 @@ const { withCorsHeaders } = require('../lib/cors');
  * "last time the pipeline checked this action". That distinction is surfaced
  * clearly in the response via the `interpretation` field.
  */
+
+async function computeStatus(tableClient) {
+  const now = new Date();
+  let totalCount = 0;
+  let newestSyncedUtc = null;
+  let oldestSyncedUtc = null;
+
+  const buckets = {
+    within1day: 0,
+    within7days: 0,
+    within30days: 0,
+    olderThan30days: 0,
+    noTimestamp: 0
+  };
+
+  for await (const entity of tableClient.listEntities()) {
+    totalCount += 1;
+
+    const raw = entity.LastSyncedUtc;
+    if (!raw) {
+      buckets.noTimestamp += 1;
+      continue;
+    }
+
+    const syncedAt = new Date(raw);
+    if (isNaN(syncedAt.getTime())) {
+      buckets.noTimestamp += 1;
+      continue;
+    }
+
+    if (!newestSyncedUtc || syncedAt > newestSyncedUtc) newestSyncedUtc = syncedAt;
+    if (!oldestSyncedUtc || syncedAt < oldestSyncedUtc) oldestSyncedUtc = syncedAt;
+
+    const ageMs = now - syncedAt;
+    const ageDays = ageMs / (1000 * 60 * 60 * 24);
+
+    if (ageDays <= 1) {
+      buckets.within1day += 1;
+    } else if (ageDays <= 7) {
+      buckets.within7days += 1;
+    } else if (ageDays <= 30) {
+      buckets.within30days += 1;
+    } else {
+      buckets.olderThan30days += 1;
+    }
+  }
+
+  return {
+    totalCount,
+    newestSyncedUtc: newestSyncedUtc ? newestSyncedUtc.toISOString() : null,
+    oldestSyncedUtc: oldestSyncedUtc ? oldestSyncedUtc.toISOString() : null,
+    ageDistribution: buckets
+  };
+}
+
 module.exports = async function actionsStatus(context, req) {
   if (req.method === 'OPTIONS') {
     context.res = {
@@ -29,64 +85,39 @@ module.exports = async function actionsStatus(context, req) {
   }
 
   const tableClient = getTableClient();
-  const now = new Date();
-
-  let totalCount = 0;
-  let newestSyncedUtc = null;
-  let oldestSyncedUtc = null;
-
-  const buckets = {
-    within1day: 0,
-    within7days: 0,
-    within30days: 0,
-    olderThan30days: 0,
-    noTimestamp: 0
-  };
+  const forceRefresh = req.query && req.query.refresh === 'true';
 
   try {
-    for await (const entity of tableClient.listEntities()) {
-      totalCount += 1;
+    let statusData;
+    let fromCache = false;
 
-      const raw = entity.LastSyncedUtc;
-      if (!raw) {
-        buckets.noTimestamp += 1;
-        continue;
-      }
-
-      const syncedAt = new Date(raw);
-      if (isNaN(syncedAt.getTime())) {
-        buckets.noTimestamp += 1;
-        continue;
-      }
-
-      if (!newestSyncedUtc || syncedAt > newestSyncedUtc) newestSyncedUtc = syncedAt;
-      if (!oldestSyncedUtc || syncedAt < oldestSyncedUtc) oldestSyncedUtc = syncedAt;
-
-      const ageMs = now - syncedAt;
-      const ageDays = ageMs / (1000 * 60 * 60 * 24);
-
-      if (ageDays <= 1) {
-        buckets.within1day += 1;
-      } else if (ageDays <= 7) {
-        buckets.within7days += 1;
-      } else if (ageDays <= 30) {
-        buckets.within30days += 1;
-      } else {
-        buckets.olderThan30days += 1;
+    if (!forceRefresh) {
+      const cached = await readCache(tableClient);
+      if (cached && cached.data && cached.data.status) {
+        statusData = cached.data.status;
+        fromCache = true;
       }
     }
 
+    if (!statusData) {
+      statusData = await computeStatus(tableClient);
+      // Write merged cache (preserve existing stats data if present)
+      const existing = await readCache(tableClient).catch(() => null);
+      const existingData = existing && existing.data ? existing.data : {};
+      await writeCache(tableClient, { ...existingData, status: statusData });
+    }
+
+    const { totalCount, newestSyncedUtc, oldestSyncedUtc, ageDistribution } = statusData;
+    context.log(`ActionsStatus: total=${totalCount}, newest=${newestSyncedUtc}, oldest=${oldestSyncedUtc}, fromCache=${fromCache}`);
+
     const payload = {
       totalCount,
-      newestSyncedUtc: newestSyncedUtc ? newestSyncedUtc.toISOString() : null,
-      oldestSyncedUtc: oldestSyncedUtc ? oldestSyncedUtc.toISOString() : null,
-      ageDistribution: buckets,
-      generatedAt: now.toISOString(),
-      // Surface the semantic clearly so consumers can label it correctly.
+      newestSyncedUtc,
+      oldestSyncedUtc,
+      ageDistribution,
+      generatedAt: new Date().toISOString(),
       interpretation: 'lastSyncedUtc is set when an action\'s data changes in the database. It is not updated on every pipeline run — actions whose data has not changed since the last upload will have an older timestamp.'
     };
-
-    context.log(`ActionsStatus: total=${totalCount}, newest=${newestSyncedUtc}, oldest=${oldestSyncedUtc}`);
 
     context.res = {
       status: 200,

--- a/src/backend/ActionsUpsert/index.js
+++ b/src/backend/ActionsUpsert/index.js
@@ -2,12 +2,26 @@ const { ActionRecord } = require('../lib/actionRecord');
 const { getTableClient, getActionEntity } = require('../lib/tableStorage');
 const { ErrorCodes, createErrorResponse, extractErrorDetails, logErrorDetails } = require('../lib/errorResponse');
 const { withCorsHeaders } = require('../lib/cors');
+const { patchCache } = require('../lib/statsCache');
 
 async function fetchExisting(tableClient, partitionKey, rowKey) {
   return getActionEntity(partitionKey, rowKey, { tableClient });
 }
 
-async function persistActionRecord(tableClient, actionRecord, existing) {
+async function persistActionRecord(tableClient, actionRecord, existing, retryCount = 0) {
+  const MAX_RETRIES = 3;
+
+  if (retryCount > MAX_RETRIES) {
+    const err = new Error(`Exceeded maximum retries (${MAX_RETRIES}) persisting action record.`);
+    err.code = 'MAX_RETRIES_EXCEEDED';
+    throw err;
+  }
+
+  const backoffMs = retryCount > 0 ? 100 * Math.pow(2, retryCount - 1) : 0;
+  if (backoffMs > 0) {
+    await new Promise(resolve => setTimeout(resolve, backoffMs));
+  }
+
   const entity = actionRecord.toEntity();
 
   if (!existing) {
@@ -19,7 +33,7 @@ async function persistActionRecord(tableClient, actionRecord, existing) {
         throw error;
       }
       const latest = await tableClient.getEntity(entity.partitionKey, entity.rowKey);
-      return persistActionRecord(tableClient, actionRecord, latest);
+      return persistActionRecord(tableClient, actionRecord, latest, retryCount + 1);
     }
   }
 
@@ -34,8 +48,78 @@ async function persistActionRecord(tableClient, actionRecord, existing) {
     if (actionRecord.matchesExisting(latest)) {
       return { updated: false, created: false, lastSyncedUtc: latest.LastSyncedUtc };
     }
-    return persistActionRecord(tableClient, actionRecord, latest);
+    return persistActionRecord(tableClient, actionRecord, latest, retryCount + 1);
   }
+}
+
+function parsePayload(entity) {
+  if (!entity) return null;
+  try {
+    return typeof entity.PayloadJson === 'string'
+      ? JSON.parse(entity.PayloadJson)
+      : (entity.PayloadJson || null);
+  } catch (_err) {
+    return null;
+  }
+}
+
+async function updateStatsCache(tableClient, record, existing, result) {
+  const newPayload = parsePayload({ PayloadJson: record.canonicalJson });
+  const oldPayload = parsePayload(existing);
+
+  const newType = newPayload && newPayload.actionType && newPayload.actionType.actionType;
+  const oldType = oldPayload && oldPayload.actionType && oldPayload.actionType.actionType;
+  const newVerified = newPayload && newPayload.verified === true;
+  const oldVerified = oldPayload && oldPayload.verified === true;
+  const newArchived = newPayload && newPayload.repoInfo && newPayload.repoInfo.archived === true;
+  const oldArchived = oldPayload && oldPayload.repoInfo && oldPayload.repoInfo.archived === true;
+  const newRawScore = newPayload ? (newPayload.openssf_score ?? newPayload.ossfScore ?? newPayload.ossf_score ?? null) : null;
+  const newHasOssf = newPayload && (newPayload.ossf === true || (newRawScore !== null && newRawScore !== undefined));
+  const oldRawScore = oldPayload ? (oldPayload.openssf_score ?? oldPayload.ossfScore ?? oldPayload.ossf_score ?? null) : null;
+  const oldHasOssf = oldPayload && (oldPayload.ossf === true || (oldRawScore !== null && oldRawScore !== undefined));
+
+  await patchCache(tableClient, (cache) => {
+    const stats = cache.stats ? { ...cache.stats } : { total: 0, byType: {}, verified: 0, archived: 0, withOssf: 0 };
+    const statusTotals = cache.status ? { ...cache.status } : null;
+
+    if (result.created) {
+      stats.total = (stats.total || 0) + 1;
+    }
+
+    if (newType !== oldType) {
+      const byType = { ...stats.byType };
+      if (newType) byType[newType] = (byType[newType] || 0) + 1;
+      if (oldType) byType[oldType] = Math.max(0, (byType[oldType] || 0) - 1);
+      stats.byType = byType;
+    }
+
+    if (newVerified !== oldVerified) {
+      stats.verified = Math.max(0, (stats.verified || 0) + (newVerified ? 1 : -1));
+    }
+
+    if (newArchived !== oldArchived) {
+      stats.archived = Math.max(0, (stats.archived || 0) + (newArchived ? 1 : -1));
+    }
+
+    if (newHasOssf !== oldHasOssf) {
+      stats.withOssf = Math.max(0, (stats.withOssf || 0) + (newHasOssf ? 1 : -1));
+    }
+
+    const updatedStatus = statusTotals ? { ...statusTotals } : null;
+    if (updatedStatus) {
+      if (result.created) {
+        updatedStatus.totalCount = (updatedStatus.totalCount || 0) + 1;
+      }
+      if (result.lastSyncedUtc) {
+        const newTs = result.lastSyncedUtc;
+        if (!updatedStatus.newestSyncedUtc || newTs > updatedStatus.newestSyncedUtc) {
+          updatedStatus.newestSyncedUtc = newTs;
+        }
+      }
+    }
+
+    return { ...cache, stats, status: updatedStatus || cache.status };
+  });
 }
 
 module.exports = async function actionsUpsert(context, req) {
@@ -95,6 +179,9 @@ module.exports = async function actionsUpsert(context, req) {
     }
 
     const result = await persistActionRecord(tableClient, record, existing);
+
+    // Best-effort incremental cache update; must not block or fail the response.
+    updateStatsCache(tableClient, record, existing, result).catch(() => {});
 
     context.res = {
       status: result.created ? 201 : 200,

--- a/src/backend/lib/statsCache.js
+++ b/src/backend/lib/statsCache.js
@@ -1,0 +1,60 @@
+const STATS_CACHE_PARTITION = 'statsCache';
+const STATS_CACHE_ROW = 'aggregate';
+
+async function readCache(tableClient) {
+  try {
+    const entity = await tableClient.getEntity(STATS_CACHE_PARTITION, STATS_CACHE_ROW);
+    if (!entity || !entity.CacheJson) return null;
+    return { data: JSON.parse(entity.CacheJson), etag: entity.etag };
+  } catch (err) {
+    if (err && err.statusCode === 404) return null;
+    throw err;
+  }
+}
+
+async function writeCache(tableClient, data) {
+  const cacheJson = JSON.stringify({ ...data, cachedAt: new Date().toISOString() });
+  const entity = {
+    partitionKey: STATS_CACHE_PARTITION,
+    rowKey: STATS_CACHE_ROW,
+    CacheJson: cacheJson
+  };
+  try {
+    await tableClient.upsertEntity(entity, 'Replace');
+  } catch (_err) {
+    // best-effort; cache write failure does not affect the response
+  }
+}
+
+// Atomically patch the cache using optimistic concurrency.
+// patchFn receives the current cache data and returns updated data (or null to skip).
+async function patchCache(tableClient, patchFn) {
+  try {
+    let entity;
+    try {
+      entity = await tableClient.getEntity(STATS_CACHE_PARTITION, STATS_CACHE_ROW);
+    } catch (err) {
+      if (err && err.statusCode === 404) return; // no cache to patch
+      throw err;
+    }
+
+    if (!entity || !entity.CacheJson) return;
+
+    const current = JSON.parse(entity.CacheJson);
+    const updated = patchFn(current);
+    if (!updated) return;
+
+    const updatedEntity = {
+      partitionKey: STATS_CACHE_PARTITION,
+      rowKey: STATS_CACHE_ROW,
+      CacheJson: JSON.stringify(updated)
+    };
+
+    await tableClient.updateEntity(updatedEntity, 'Replace', { etag: entity.etag });
+  } catch (err) {
+    if (err && err.statusCode === 412) return; // ETag conflict - cache will drift, OK
+    // Swallow other errors; patch is best-effort and must not break the main flow
+  }
+}
+
+module.exports = { readCache, writeCache, patchCache };

--- a/src/backend/tests/actionsStats.test.js
+++ b/src/backend/tests/actionsStats.test.js
@@ -17,13 +17,24 @@ function createContext() {
   };
 }
 
-function createFakeTableClient(entities) {
+function createFakeTableClient(entities, { cacheEntity = null } = {}) {
   return {
     url: 'http://127.0.0.1:10002/devstoreaccount1/actions',
     async *listEntities() {
       for (const entity of entities) {
         yield entity;
       }
+    },
+    async getEntity(partitionKey, rowKey) {
+      if (partitionKey === 'statsCache' && rowKey === 'aggregate' && cacheEntity) {
+        return cacheEntity;
+      }
+      const err = new Error('Not Found');
+      err.statusCode = 404;
+      throw err;
+    },
+    async upsertEntity() {
+      // no-op for tests
     }
   };
 }
@@ -234,7 +245,9 @@ describe('ActionsStats function', () => {
       url: 'http://127.0.0.1:10002/devstoreaccount1/actions?sv=2021',
       async *listEntities() {
         yield { PayloadJson: JSON.stringify({ verified: false, actionType: null, repoInfo: null }) };
-      }
+      },
+      async getEntity() { const e = new Error(); e.statusCode = 404; throw e; },
+      async upsertEntity() {}
     };
     getTableClient.mockReturnValue(fakeClient);
 
@@ -247,5 +260,47 @@ describe('ActionsStats function', () => {
     const tableEndpoint = context.res.headers['X-Table-Endpoint'];
     expect(tableEndpoint).not.toContain('?');
     expect(tableEndpoint).toContain('actions');
+  });
+
+  it('returns cached stats without scanning entities', async () => {
+    const cachedData = {
+      stats: { total: 99, byType: { Node: 50, Docker: 49 }, verified: 10, archived: 5, withOssf: 20 }
+    };
+    const cacheEntity = { CacheJson: JSON.stringify(cachedData), etag: '"abc"' };
+    getTableClient.mockReturnValue(createFakeTableClient([], { cacheEntity }));
+
+    const context = createContext();
+    const req = { method: 'GET', headers: {}, query: {} };
+
+    await actionsStats(context, req);
+
+    expect(context.res.status).toBe(200);
+    const body = JSON.parse(context.res.body);
+    expect(body.total).toBe(99);
+    expect(body.verified).toBe(10);
+    expect(body.archived).toBe(5);
+    expect(body.withOssf).toBe(20);
+  });
+
+  it('forces full scan when refresh=true even with cached data', async () => {
+    const cachedData = {
+      stats: { total: 99, byType: {}, verified: 0, archived: 0, withOssf: 0 }
+    };
+    const cacheEntity = { CacheJson: JSON.stringify(cachedData), etag: '"abc"' };
+    const entities = [
+      { PayloadJson: JSON.stringify({ verified: true, actionType: { actionType: 'Node' }, repoInfo: { archived: false } }) }
+    ];
+    getTableClient.mockReturnValue(createFakeTableClient(entities, { cacheEntity }));
+
+    const context = createContext();
+    const req = { method: 'GET', headers: {}, query: { refresh: 'true' } };
+
+    await actionsStats(context, req);
+
+    expect(context.res.status).toBe(200);
+    const body = JSON.parse(context.res.body);
+    // Should reflect the actual scan result (1 entity), not the stale cache (99)
+    expect(body.total).toBe(1);
+    expect(body.verified).toBe(1);
   });
 });

--- a/src/frontend/src/pages/OverviewPage.tsx
+++ b/src/frontend/src/pages/OverviewPage.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useRef, useState } from 'react';
+import React, { useEffect, useMemo, useRef, useState, useDeferredValue } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { Action, ActionStats, ActionTypeFilter } from '../types/Action';
 import { actionsService, parseDependentsCount, formatDependentsCount } from '../services/actionsService';
@@ -54,8 +54,9 @@ export const OverviewPage: React.FC = () => {
   const initialStats = actionsService.getStats();
 
   const [actions, setActions] = useState<Action[]>(initialActions);
-  const [filteredActions, setFilteredActions] = useState<Action[]>([]);
   const [searchQuery, setSearchQuery] = useState(() => (initialPersisted?.searchQuery ?? ''));
+  // Defer search query so each keystroke does not trigger a synchronous filter pass
+  const deferredSearchQuery = useDeferredValue(searchQuery);
   const [typeFilter, setTypeFilter] = useState<ActionTypeFilter>(() => {
     const candidate = initialPersisted?.typeFilter;
     const supported: ActionTypeFilter[] = ['All', 'Node', 'Docker', 'Composite', 'Unknown', 'No file found'];
@@ -89,7 +90,7 @@ export const OverviewPage: React.FC = () => {
   const navigate = useNavigate();
 
   const prevFiltersRef = useRef({
-    searchQuery,
+    searchQuery: deferredSearchQuery,
     typeFilter,
     showVerifiedOnly,
     archivedFilter,
@@ -215,10 +216,12 @@ export const OverviewPage: React.FC = () => {
     });
   }, [searchQuery, typeFilter, showVerifiedOnly, verifiedFilter, archivedFilter, activityFilter, sortBy, openssfFilter, currentPage]);
 
-  useEffect(() => {
+  // Memoize filter+sort to avoid recomputing on every render.
+  // Uses deferredSearchQuery so typing does not block the UI.
+  const filteredActions = useMemo(() => {
     let filtered = actions;
 
-    const normalizedQuery = searchQuery.trim();
+    const normalizedQuery = deferredSearchQuery.trim();
     if (normalizedQuery) {
       filtered = filtered.filter(action => matchesSearchQuery({ owner: action.owner, name: action.name }, normalizedQuery));
     }
@@ -266,7 +269,7 @@ export const OverviewPage: React.FC = () => {
     }
 
     // Apply sorting
-    filtered = [...filtered].sort((a, b) => {
+    return [...filtered].sort((a, b) => {
       if (sortBy === 'dependents') {
         const aDeps = parseDependentsCount(a?.dependents?.dependents);
         const bDeps = parseDependentsCount(b?.dependents?.dependents);
@@ -278,12 +281,13 @@ export const OverviewPage: React.FC = () => {
         return bDate - aDate; // Descending (most recent first)
       }
     });
+  }, [actions, deferredSearchQuery, typeFilter, showVerifiedOnly, archivedFilter, activityFilter, verifiedFilter, sortBy, openssfFilter]);
 
-    setFilteredActions(filtered);
-
+  // Reset page to 1 when filter criteria change; clamp when only the actions list updates.
+  useEffect(() => {
     const prev = prevFiltersRef.current;
     const filtersChanged =
-      prev.searchQuery !== searchQuery ||
+      prev.searchQuery !== deferredSearchQuery ||
       prev.typeFilter !== typeFilter ||
       prev.showVerifiedOnly !== showVerifiedOnly ||
       prev.verifiedFilter !== verifiedFilter ||
@@ -292,15 +296,15 @@ export const OverviewPage: React.FC = () => {
       prev.sortBy !== sortBy ||
       prev.openssfFilter !== openssfFilter;
 
-      prevFiltersRef.current = { searchQuery, typeFilter, showVerifiedOnly, archivedFilter, activityFilter, verifiedFilter, sortBy, openssfFilter };
+    prevFiltersRef.current = { searchQuery: deferredSearchQuery, typeFilter, showVerifiedOnly, archivedFilter, activityFilter, verifiedFilter, sortBy, openssfFilter };
 
-    const nextTotalPages = Math.max(1, Math.ceil(filtered.length / PAGE_SIZE));
+    const nextTotalPages = Math.max(1, Math.ceil(filteredActions.length / PAGE_SIZE));
     if (filtersChanged) {
       setCurrentPage(1);
     } else {
       setCurrentPage(p => Math.min(Math.max(p, 1), nextTotalPages));
     }
-  }, [actions, searchQuery, typeFilter, showVerifiedOnly, archivedFilter, activityFilter, verifiedFilter, sortBy, openssfFilter]);
+  }, [filteredActions, deferredSearchQuery, typeFilter, showVerifiedOnly, archivedFilter, activityFilter, verifiedFilter, sortBy, openssfFilter]);
 
   useEffect(() => {
     if (restoredScrollRef.current) {


### PR DESCRIPTION
## Summary

Four high-impact optimizations addressing performance, correctness, and UX issues.

---

### fixes #169 - Eliminate full-table scans in ActionsStats and ActionsStatus

Both endpoints previously iterated every entity in Table Storage on every HTTP call (~30k rows per request).

Changes:
- New src/backend/lib/statsCache.js helper with readCache, writeCache, and patchCache (ETag-based optimistic concurrency).
- ActionsStats and ActionsStatus now read a single statsCache/aggregate row instead of scanning all entities.
- On cache miss, both fall back to a full scan and populate the cache.
- refresh=true forces a full recompute for admin use.
- ActionsUpsert increments stats/status counts in the cache after each successful upsert (best-effort, ETag-protected).

---

### fixes #175 - Add max-retry guard to ActionsUpsert

persistActionRecord previously recursed without bound on 412/409 conflicts.

Changes:
- MAX_RETRIES = 3 guard; throws MAX_RETRIES_EXCEEDED when exceeded.
- Exponential back-off: 100ms x 2^(retryCount-1) between retries.

---

### fixes #170 - Memoize filter/sort computation in OverviewPage

The filter+sort pipeline ran on every render via a useEffect + setFilteredActions state write.

Changes:
- Removed filteredActions state.
- Replaced the useEffect with useMemo; filteredActions is now a pure derived value recomputed only when its dependencies change.

---

### fixes #167 - Defer expensive search updates in OverviewPage

Every keystroke triggered a synchronous filter pass over all ~30k actions.

Changes:
- useDeferredValue(searchQuery) wraps the search query fed into the useMemo filter pipeline.
- The input field updates immediately; the heavy filter computation is deferred until the browser is idle (React 18 concurrent rendering).
- No new dependency added.

---

## Tests

- 106/106 backend tests passing.
- 6 suites fail pre-existing (missing @azure/data-tables / @octokit/auth-app packages, unrelated to these changes).
- No workflow changes in this PR.