### PR TITLE
security: sanitize the version query parameter in ActionsReadme

### DIFF
--- a/src/backend/ActionsReadme/index.js
+++ b/src/backend/ActionsReadme/index.js
@@ -5,6 +5,23 @@ const { getActionEntity } = require('../lib/tableStorage');
 const { ActionRecord } = require('../lib/actionRecord');
 const { extractRepoName } = require('../lib/actionNameDecoder');
 
+// GitHub owner/org names: alphanumeric and hyphens only.
+const VALID_OWNER = /^[a-zA-Z0-9-]+$/;
+// Action "name" route segment may encode composite action paths as
+// {owner}_{repo}_{subpath} (see actionNameDecoder.js), so it also allows
+// underscores and dots (e.g. ".github").
+const VALID_NAME = /^[a-zA-Z0-9._-]+$/;
+// Characters that are valid in a git ref/tag/branch name.
+const INVALID_REF_CHARS = /[^a-zA-Z0-9._\-/]/g;
+
+function sanitizeVersion(rawVersion) {
+  if (!rawVersion) {
+    return 'main';
+  }
+  const sanitized = String(rawVersion).replace(INVALID_REF_CHARS, '');
+  return sanitized || 'main';
+}
+
 async function fetchReadmeFromGitHub(owner, name, version) {
   const ref = version || 'main';
   const repoName = extractRepoName(owner, name);
@@ -72,13 +89,22 @@ module.exports = async function actionsReadme(context, req) {
 
   const owner = context.bindingData && context.bindingData.owner;
   const name = context.bindingData && context.bindingData.name;
-  const version = req.query && req.query.version;
+  const version = sanitizeVersion(req.query && req.query.version);
 
   if (!owner || !name) {
     context.res = {
       status: 400,
       headers: withCorsHeaders(req),
       body: { error: 'Owner and name route parameters are required.' }
+    };
+    return;
+  }
+
+  if (!VALID_OWNER.test(owner) || !VALID_NAME.test(name)) {
+    context.res = {
+      status: 400,
+      headers: withCorsHeaders(req),
+      body: { error: 'Owner and name route parameters contain invalid characters.' }
     };
     return;
   }

--- a/src/backend/tests/actionsReadme.test.js
+++ b/src/backend/tests/actionsReadme.test.js
@@ -243,4 +243,80 @@ describe('actionsReadme function', () => {
       expect.any(Object)
     );
   });
+
+  it('strips characters that are not valid in a git ref from the version query param', async () => {
+    mockGetActionEntity.mockResolvedValue(null);
+    mockGetCachedReadme.mockResolvedValue(null);
+    mockCacheReadme.mockResolvedValue(undefined);
+
+    global.fetch.mockResolvedValue({
+      ok: true,
+      status: 200,
+      text: jest.fn().mockResolvedValue('<h2>sanitized README</h2>')
+    });
+
+    const context = createContext('actions', 'checkout');
+    const req = {
+      method: 'GET',
+      headers: {},
+      // Attempt to inject extra path/query segments via the version param.
+      query: { version: '../../evil?foo=bar&x=<script>' }
+    };
+
+    await actionsReadme(context, req);
+
+    expect(context.res.status).toBe(200);
+    const fetchedUrl = global.fetch.mock.calls[0][0];
+    // The only "?" in the URL should be the one separating the readme path
+    // from the "ref" query param itself — no extra query params or markup
+    // should have leaked in from the (malicious) version value.
+    expect(fetchedUrl.indexOf('?')).toBe(fetchedUrl.lastIndexOf('?'));
+    expect(fetchedUrl).not.toMatch(/[<>&]/);
+    expect(fetchedUrl).toContain('ref=../../evilfoobarxscript');
+  });
+
+  it('falls back to "main" when the sanitized version is empty', async () => {
+    mockGetActionEntity.mockResolvedValue(null);
+    mockGetCachedReadme.mockResolvedValue(null);
+    mockCacheReadme.mockResolvedValue(undefined);
+
+    global.fetch.mockResolvedValue({
+      ok: true,
+      status: 200,
+      text: jest.fn().mockResolvedValue('<h2>main README</h2>')
+    });
+
+    const context = createContext('actions', 'checkout');
+    const req = { method: 'GET', headers: {}, query: { version: '!!!***' } };
+
+    await actionsReadme(context, req);
+
+    expect(context.res.status).toBe(200);
+    expect(global.fetch).toHaveBeenCalledWith(
+      expect.stringContaining('ref=main'),
+      expect.any(Object)
+    );
+  });
+
+  it('returns 400 when owner contains invalid characters', async () => {
+    const context = createContext('actions/evil', 'checkout');
+    const req = { method: 'GET', headers: {}, query: {} };
+
+    await actionsReadme(context, req);
+
+    expect(context.res.status).toBe(400);
+    expect(context.res.body.error).toContain('invalid characters');
+    expect(global.fetch).not.toHaveBeenCalled();
+  });
+
+  it('returns 400 when name contains invalid characters', async () => {
+    const context = createContext('actions', 'checkout/../secrets');
+    const req = { method: 'GET', headers: {}, query: {} };
+
+    await actionsReadme(context, req);
+
+    expect(context.res.status).toBe(400);
+    expect(context.res.body.error).toContain('invalid characters');
+    expect(global.fetch).not.toHaveBeenCalled();
+  });
 });


### PR DESCRIPTION
## Summary
- `src/backend/ActionsReadme/index.js` built the GitHub readme API URL using the `version` query parameter (as the `ref` value) without any validation, so a crafted `version` value could inject extra query parameters or path/ref segments into the outbound GitHub request.
- Added `sanitizeVersion()` which strips any character not valid in a git ref/tag/branch name (keeping `[a-zA-Z0-9._-/]`) and falls back to `'main'` if the sanitized value is empty.
- Added validation for the `owner` and `name` route parameters against allow-listed character sets before they're used to build any GitHub URL. Requests with invalid `owner`/`name` now get a `400` response, consistent with the function's existing error-response pattern.

## Test plan
- [x] Added tests in `src/backend/tests/actionsReadme.test.js` covering: a crafted `version` value is sanitized before being sent to GitHub, an all-invalid `version` falls back to `main`, and invalid `owner`/`name` values are rejected with 400.
- [x] `npm test` in `src/backend` passes (221/221 tests, including the 20 in `actionsReadme.test.js`).
- [x] `npm run lint` in `src/backend` was attempted but currently fails on `main` as well (pre-existing, unrelated issue: ESLint 10.7.0 no longer supports `.eslintrc.json`/`.eslintignore` without an `eslint.config.js`, introduced by the recent eslint dependency bump). Verified via `git stash` that this failure is present on `main` before this change, so it isn't caused by this PR.

Closes #176