### PR TITLE
perf: cache README responses client-side in actionsService

### DIFF
--- a/src/frontend/src/services/actionsService.ts
+++ b/src/frontend/src/services/actionsService.ts
@@ -1,10 +1,18 @@
 import { Action, ActionStats, DbStatus } from '../types/Action';
 
 const REFRESH_INTERVAL = 5 * 60 * 1000; // 5 minutes
+const README_TTL_MS = 10 * 60 * 1000; // 10 minutes
+
+interface ReadmeCacheEntry {
+  content: string | null;
+  cachedAt: number;
+}
 
 function getApiBaseUrl(): string {
   const fallback = '/api';
-  const configured = import.meta.env.VITE_API_BASE_URL;
+  // Optional chaining on `env` keeps this safe when the module is imported outside of
+  // Vite (e.g. by the Playwright test runner), where `import.meta.env` is undefined.
+  const configured = import.meta.env?.VITE_API_BASE_URL;
 
   if (!configured) {
     return fallback;
@@ -177,7 +185,7 @@ function extractArrayFromUnknown(value: unknown): unknown[] {
   return [];
 }
 
-class ActionsService {
+export class ActionsService {
   private actions: Action[] = [];
   private loading: boolean = false;
   private lastFetch: number = 0;
@@ -188,6 +196,7 @@ class ActionsService {
   private inFlightActionsFetch: Promise<Action[]> | null = null;
   private inFlightStatsFetch: Promise<ActionStats> | null = null;
   private inFlightDbStatusFetch: Promise<DbStatus> | null = null;
+  private readmeCache: Map<string, ReadmeCacheEntry> = new Map();
 
   constructor() {
     this.startAutoRefresh();
@@ -375,6 +384,12 @@ class ActionsService {
   }
 
   async fetchReadme(owner: string, name: string, version?: string): Promise<string | null> {
+    const cacheKey = `${owner.toLowerCase()}/${name.toLowerCase()}@${version ?? ''}`;
+    const cached = this.readmeCache.get(cacheKey);
+    if (cached && (Date.now() - cached.cachedAt) < README_TTL_MS) {
+      return cached.content;
+    }
+
     try {
       const versionParam = version ? `?version=${encodeURIComponent(version)}` : '';
       const response = await fetch(
@@ -383,12 +398,15 @@ class ActionsService {
       );
       if (!response.ok) {
         if (response.status === 404) {
+          this.readmeCache.set(cacheKey, { content: null, cachedAt: Date.now() });
           return null;
         }
         throw new Error(`Failed to fetch README: ${response.statusText}`);
       }
 
-      return await response.text();
+      const content = await response.text();
+      this.readmeCache.set(cacheKey, { content, cachedAt: Date.now() });
+      return content;
     } catch (error) {
       console.error('Error fetching README:', error);
       throw error;
@@ -424,6 +442,7 @@ class ActionsService {
       clearInterval(this.refreshTimer);
     }
     this.listeners = [];
+    this.readmeCache.clear();
   }
 }
 

--- a/src/frontend/tests/actionsService.spec.ts
+++ b/src/frontend/tests/actionsService.spec.ts
@@ -1,0 +1,138 @@
+import { test, expect } from '@playwright/test';
+import { ActionsService } from '../src/services/actionsService';
+
+type FetchStub = (input: RequestInfo | URL, init?: RequestInit) => Promise<Response>;
+
+function makeCountingFetch(): { fetchStub: FetchStub; getCallCount: () => number } {
+  let callCount = 0;
+  const fetchStub: FetchStub = async () => {
+    callCount += 1;
+    return {
+      ok: true,
+      status: 200,
+      statusText: 'OK',
+      text: async () => `content-${callCount}`
+    } as Response;
+  };
+  return { fetchStub, getCallCount: () => callCount };
+}
+
+test.describe('actionsService README client-side cache', () => {
+  let originalFetch: typeof fetch;
+
+  test.beforeEach(() => {
+    originalFetch = global.fetch;
+  });
+
+  test.afterEach(() => {
+    global.fetch = originalFetch;
+  });
+
+  test('a second call within the TTL does not hit the network again', async () => {
+    const { fetchStub, getCallCount } = makeCountingFetch();
+    global.fetch = fetchStub as typeof fetch;
+
+    const service = new ActionsService();
+    try {
+      const first = await service.fetchReadme('owner1', 'repo1', 'v1.0.0');
+      expect(getCallCount()).toBe(1);
+      expect(first).toBe('content-1');
+
+      const second = await service.fetchReadme('owner1', 'repo1', 'v1.0.0');
+      expect(getCallCount()).toBe(1);
+      expect(second).toBe('content-1');
+    } finally {
+      service.destroy();
+    }
+  });
+
+  test('a call for a different version fetches again', async () => {
+    const { fetchStub, getCallCount } = makeCountingFetch();
+    global.fetch = fetchStub as typeof fetch;
+
+    const service = new ActionsService();
+    try {
+      await service.fetchReadme('owner1', 'repo1', 'v1.0.0');
+      expect(getCallCount()).toBe(1);
+
+      await service.fetchReadme('owner1', 'repo1', 'v2.0.0');
+      expect(getCallCount()).toBe(2);
+    } finally {
+      service.destroy();
+    }
+  });
+
+  test('a call for a different owner or name fetches again', async () => {
+    const { fetchStub, getCallCount } = makeCountingFetch();
+    global.fetch = fetchStub as typeof fetch;
+
+    const service = new ActionsService();
+    try {
+      await service.fetchReadme('owner1', 'repo1', 'v1.0.0');
+      expect(getCallCount()).toBe(1);
+
+      await service.fetchReadme('owner2', 'repo1', 'v1.0.0');
+      expect(getCallCount()).toBe(2);
+
+      await service.fetchReadme('owner1', 'repo2', 'v1.0.0');
+      expect(getCallCount()).toBe(3);
+    } finally {
+      service.destroy();
+    }
+  });
+
+  test('cache entry expires after the TTL and triggers a new fetch', async () => {
+    const { fetchStub, getCallCount } = makeCountingFetch();
+    global.fetch = fetchStub as typeof fetch;
+
+    const realNow = Date.now;
+    let now = realNow();
+    Date.now = () => now;
+
+    const service = new ActionsService();
+    try {
+      await service.fetchReadme('owner1', 'repo1', 'v1.0.0');
+      expect(getCallCount()).toBe(1);
+
+      // Still within the 10-minute TTL.
+      now += 9 * 60 * 1000;
+      await service.fetchReadme('owner1', 'repo1', 'v1.0.0');
+      expect(getCallCount()).toBe(1);
+
+      // Past the 10-minute TTL.
+      now += 2 * 60 * 1000;
+      const afterExpiry = await service.fetchReadme('owner1', 'repo1', 'v1.0.0');
+      expect(getCallCount()).toBe(2);
+      expect(afterExpiry).toBe('content-2');
+    } finally {
+      Date.now = realNow;
+      service.destroy();
+    }
+  });
+
+  test('a 404 response is cached as a miss and is not retried within the TTL', async () => {
+    let callCount = 0;
+    global.fetch = (async () => {
+      callCount += 1;
+      return {
+        ok: false,
+        status: 404,
+        statusText: 'Not Found',
+        text: async () => ''
+      } as Response;
+    }) as typeof fetch;
+
+    const service = new ActionsService();
+    try {
+      const first = await service.fetchReadme('owner1', 'repo1', 'v1.0.0');
+      expect(callCount).toBe(1);
+      expect(first).toBeNull();
+
+      const second = await service.fetchReadme('owner1', 'repo1', 'v1.0.0');
+      expect(callCount).toBe(1);
+      expect(second).toBeNull();
+    } finally {
+      service.destroy();
+    }
+  });
+});


### PR DESCRIPTION
## Summary

`DetailPage.tsx` calls `actionsService.fetchReadme(owner, name, version)` on mount and on every version change, even when the same `owner/name/version` was fetched moments earlier. This causes unnecessary round-trips to the backend (and GitHub) whenever a user re-visits a detail page or toggles between versions they've already viewed.

This PR adds a simple in-memory cache to `ActionsService.fetchReadme` in `src/frontend/src/services/actionsService.ts`:

- Cache entries are keyed by `owner/name@version` (case-insensitive on owner/name).
- Entries have a 10-minute TTL, checked on read — no extra eviction/size-limiting infrastructure.
- Successful README fetches and explicit 404 ("not found") results are both cached, so repeat visits within the TTL avoid the network call in either case.
- Network/other errors are not cached, so a failed fetch is retried on the next call.
- `ActionsService.destroy()` now also clears the README cache.

As a small supporting change, `getApiBaseUrl()` now accesses `import.meta.env` with optional chaining so the module can be imported directly by the Playwright test runner (which runs outside of Vite, where `import.meta.env` is `undefined`) — this was needed to unit test `fetchReadme` without spinning up a full Vite/browser environment.

## Tests

Added `src/frontend/tests/actionsService.spec.ts` covering:
- A second call for the same `owner/name/version` within the TTL does not hit the network again.
- A call for a different version, owner, or name does hit the network.
- Cache entries expire after the 10-minute TTL and trigger a new fetch.
- A 404 response is cached as a "miss" and not retried within the TTL.

## Test plan

- [x] `npm run build` (tsc + vite build) passes in `src/frontend`
- [x] `npx playwright test tests/utils.spec.ts tests/isActionVerified.spec.ts tests/actionsService.spec.ts` — all 14 tests pass
- [ ] Full e2e suite (`npm run test:e2e`) requires a running backend/frontend and was not run in this environment

Closes #168