### PR TITLE
api: add HTTP Cache-Control headers to all GET endpoints

### DIFF
--- a/src/backend/ActionsGet/index.js
+++ b/src/backend/ActionsGet/index.js
@@ -1,6 +1,9 @@
 const { ActionRecord } = require('../lib/actionRecord');
 const { getActionEntity } = require('../lib/tableStorage');
 const { withCorsHeaders } = require('../lib/cors');
+const { cacheControlHeaders } = require('../lib/cacheHeaders');
+
+const CACHE_MAX_AGE_SECONDS = 600; // 10 minutes
 
 function normalizeLastSynced(value) {
   if (typeof value !== 'string') {
@@ -93,7 +96,7 @@ module.exports = async function actionsGet(context, req) {
 
     context.res = {
       status: 200,
-      headers: withCorsHeaders(req),
+      headers: withCorsHeaders(req, cacheControlHeaders(CACHE_MAX_AGE_SECONDS)),
       body
     };
   } catch (error) {

--- a/src/backend/ActionsList/index.js
+++ b/src/backend/ActionsList/index.js
@@ -1,6 +1,9 @@
 const { getTableClient } = require('../lib/tableStorage');
 const { ActionRecord } = require('../lib/actionRecord');
 const { withCorsHeaders } = require('../lib/cors');
+const { cacheControlHeaders } = require('../lib/cacheHeaders');
+
+const CACHE_MAX_AGE_SECONDS = 300; // 5 minutes
 
 module.exports = async function actionsList(context, req) {
   if (req.method === 'OPTIONS') {
@@ -71,7 +74,8 @@ module.exports = async function actionsList(context, req) {
       headers: {
         'X-Actions-Count': results.length,
         'X-Table-Endpoint': tableUrl,
-        'Content-Type': 'application/json'
+        'Content-Type': 'application/json',
+        ...cacheControlHeaders(CACHE_MAX_AGE_SECONDS)
       },
       body: results
     };
@@ -117,7 +121,8 @@ module.exports = async function actionsList(context, req) {
       headers: {
         'X-Actions-Count': results.length,
         'X-Table-Endpoint': tableUrl,
-        'Content-Type': 'application/json'
+        'Content-Type': 'application/json',
+        ...cacheControlHeaders(CACHE_MAX_AGE_SECONDS)
       },
       body: results
     };

--- a/src/backend/ActionsReadme/index.js
+++ b/src/backend/ActionsReadme/index.js
@@ -4,6 +4,9 @@ const { getCachedReadme, cacheReadme, isCacheValid } = require('../lib/readmeCac
 const { getActionEntity } = require('../lib/tableStorage');
 const { ActionRecord } = require('../lib/actionRecord');
 const { extractRepoName } = require('../lib/actionNameDecoder');
+const { cacheControlHeaders } = require('../lib/cacheHeaders');
+
+const CACHE_MAX_AGE_SECONDS = 1800; // 30 minutes
 
 async function fetchReadmeFromGitHub(owner, name, version) {
   const ref = version || 'main';
@@ -95,9 +98,10 @@ module.exports = async function actionsReadme(context, req) {
       context.log.info(`Serving cached README for ${owner}/${name}@${version || 'main'}`);
       context.res = {
         status: 200,
-        headers: withCorsHeaders(req, { 
+        headers: withCorsHeaders(req, {
           'Content-Type': 'text/html; charset=utf-8',
-          'X-Cache': 'HIT'
+          'X-Cache': 'HIT',
+          ...cacheControlHeaders(CACHE_MAX_AGE_SECONDS)
         }),
         body: cachedReadme.content
       };
@@ -128,9 +132,10 @@ module.exports = async function actionsReadme(context, req) {
 
     context.res = {
       status: 200,
-      headers: withCorsHeaders(req, { 
+      headers: withCorsHeaders(req, {
         'Content-Type': 'text/html; charset=utf-8',
-        'X-Cache': 'MISS'
+        'X-Cache': 'MISS',
+        ...cacheControlHeaders(CACHE_MAX_AGE_SECONDS)
       }),
       body: readmeHtml
     };

--- a/src/backend/ActionsStats/index.js
+++ b/src/backend/ActionsStats/index.js
@@ -1,6 +1,9 @@
 const { getTableClient } = require('../lib/tableStorage');
 const { withCorsHeaders } = require('../lib/cors');
 const { readCache, writeCache } = require('../lib/statsCache');
+const { cacheControlHeaders } = require('../lib/cacheHeaders');
+
+const CACHE_MAX_AGE_SECONDS = 300; // 5 minutes
 
 async function computeStats(tableClient) {
   let total = 0;
@@ -100,7 +103,8 @@ module.exports = async function actionsStats(context, req) {
         'X-Archived-Count': archived,
         'X-Ossf-Count': withOssf,
         'X-Table-Endpoint': tableUrl,
-        'Content-Type': 'application/json'
+        'Content-Type': 'application/json',
+        ...cacheControlHeaders(CACHE_MAX_AGE_SECONDS)
       }),
       body: JSON.stringify(payload)
     };

--- a/src/backend/ActionsStatus/index.js
+++ b/src/backend/ActionsStatus/index.js
@@ -1,6 +1,9 @@
 const { getTableClient } = require('../lib/tableStorage');
 const { withCorsHeaders } = require('../lib/cors');
 const { readCache, writeCache } = require('../lib/statsCache');
+const { cacheControlHeaders } = require('../lib/cacheHeaders');
+
+const CACHE_MAX_AGE_SECONDS = 300; // 5 minutes
 
 /**
  * Returns data-freshness metrics for the actions database.
@@ -122,7 +125,10 @@ module.exports = async function actionsStatus(context, req) {
     context.res = {
       status: 200,
       isRaw: true,
-      headers: withCorsHeaders(req, { 'Content-Type': 'application/json' }),
+      headers: withCorsHeaders(req, {
+        'Content-Type': 'application/json',
+        ...cacheControlHeaders(CACHE_MAX_AGE_SECONDS)
+      }),
       body: JSON.stringify(payload)
     };
   } catch (error) {

--- a/src/backend/lib/cacheHeaders.js
+++ b/src/backend/lib/cacheHeaders.js
@@ -1,0 +1,16 @@
+/**
+ * Builds a `Cache-Control` header for a public, cacheable response.
+ *
+ * Only successful (2xx) GET responses should be cached — error responses
+ * must never carry this header so clients/CDNs always revalidate them.
+ *
+ * @param {number} maxAgeSeconds - freshness lifetime in seconds.
+ * @returns {{ 'Cache-Control': string }}
+ */
+function cacheControlHeaders(maxAgeSeconds) {
+  return { 'Cache-Control': `public, max-age=${maxAgeSeconds}` };
+}
+
+module.exports = {
+  cacheControlHeaders
+};

--- a/src/backend/tests/actionsGet.test.js
+++ b/src/backend/tests/actionsGet.test.js
@@ -56,6 +56,8 @@ describe('ActionsGet function', () => {
 
     // New field: openssf_score should be exposed (nullable) and reflect the payload's score when available.
     expect(context.res.body.openssf_score).toBe(basePayload.ossfScore);
+
+    expect(context.res.headers['Cache-Control']).toBe('public, max-age=600');
   });
 
   it('returns 404 when the entity is missing', async () => {
@@ -68,6 +70,7 @@ describe('ActionsGet function', () => {
 
     expect(context.res.status).toBe(404);
     expect(context.res.body).toEqual({ error: 'Action not found.' });
+    expect(context.res.headers['Cache-Control']).toBeUndefined();
   });
 
   it('returns 400 when owner or name is missing', async () => {

--- a/src/backend/tests/actionsList.test.js
+++ b/src/backend/tests/actionsList.test.js
@@ -70,6 +70,7 @@ describe('ActionsList function', () => {
     expect(context.res.status).toBe(200);
     expect(context.res.body).toHaveLength(100);
     expect(context.res.headers['X-Actions-Count']).toBe(100);
+    expect(context.res.headers['Cache-Control']).toBe('public, max-age=300');
   });
 
   test('should limit results when limit parameter is provided', async () => {
@@ -249,6 +250,7 @@ describe('ActionsList real table client path', () => {
     expect(context.res.status).toBe(200);
     expect(context.res.body).toHaveLength(2);
     expect(context.res.headers['X-Actions-Count']).toBe(2);
+    expect(context.res.headers['Cache-Control']).toBe('public, max-age=300');
   });
 
   test('applies limit during iteration', async () => {
@@ -293,5 +295,6 @@ describe('ActionsList real table client path', () => {
 
     expect(context.res.status).toBe(500);
     expect(context.res.body.error).toBe('Failed to query actions from table storage.');
+    expect(context.res.headers['Cache-Control']).toBeUndefined();
   });
 });

--- a/src/backend/tests/actionsReadme.test.js
+++ b/src/backend/tests/actionsReadme.test.js
@@ -136,6 +136,7 @@ describe('actionsReadme function', () => {
     expect(context.res.status).toBe(200);
     expect(context.res.body).toBe('<h1>README</h1>');
     expect(context.res.headers['X-Cache']).toBe('HIT');
+    expect(context.res.headers['Cache-Control']).toBe('public, max-age=1800');
     expect(global.fetch).not.toHaveBeenCalled();
   });
 
@@ -159,6 +160,7 @@ describe('actionsReadme function', () => {
     expect(context.res.status).toBe(200);
     expect(context.res.body).toBe('<h1>Fresh README</h1>');
     expect(context.res.headers['X-Cache']).toBe('MISS');
+    expect(context.res.headers['Cache-Control']).toBe('public, max-age=1800');
   });
 
   it('returns 404 when GitHub returns 404', async () => {
@@ -178,6 +180,7 @@ describe('actionsReadme function', () => {
 
     expect(context.res.status).toBe(404);
     expect(context.res.body.error).toBe('README not found.');
+    expect(context.res.headers['Cache-Control']).toBeUndefined();
   });
 
   it('returns 500 when GitHub returns non-ok non-404 error', async () => {

--- a/src/backend/tests/actionsStats.test.js
+++ b/src/backend/tests/actionsStats.test.js
@@ -79,6 +79,7 @@ describe('ActionsStats function', () => {
     expect(context.res.headers['X-Verified-Count']).toBe(1);
     expect(context.res.headers['X-Archived-Count']).toBe(1);
     expect(context.res.headers['X-Ossf-Count']).toBe(1);
+    expect(context.res.headers['Cache-Control']).toBe('public, max-age=300');
 
     const body = JSON.parse(context.res.body);
     expect(body).toEqual(
@@ -128,6 +129,7 @@ describe('ActionsStats function', () => {
 
     expect(context.res.status).toBe(500);
     expect(context.res.body.error).toBe('Failed to compute stats.');
+    expect(context.res.headers['Cache-Control']).toBeUndefined();
   });
 
   it('skips malformed PayloadJson without throwing', async () => {

--- a/src/backend/tests/actionsStatus.test.js
+++ b/src/backend/tests/actionsStatus.test.js
@@ -1,0 +1,114 @@
+jest.mock('../lib/tableStorage', () => ({
+  getTableClient: jest.fn()
+}));
+
+const { getTableClient } = require('../lib/tableStorage');
+const actionsStatus = require('../ActionsStatus');
+
+function createContext() {
+  const logFn = jest.fn();
+  logFn.info = jest.fn();
+  logFn.warn = jest.fn();
+  logFn.error = jest.fn();
+
+  return {
+    log: logFn,
+    res: null
+  };
+}
+
+function createFakeTableClient(entities) {
+  return {
+    url: 'http://127.0.0.1:10002/devstoreaccount1/actions',
+    async *listEntities() {
+      for (const entity of entities) {
+        yield entity;
+      }
+    },
+    async getEntity() {
+      const err = new Error('Not Found');
+      err.statusCode = 404;
+      throw err;
+    },
+    async upsertEntity() {
+      // no-op for tests
+    }
+  };
+}
+
+describe('ActionsStatus function', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    delete process.env.CORS_ALLOWED_ORIGINS;
+    delete process.env.CORS_ALLOW_ORIGINS;
+  });
+
+  it('returns 200 with age distribution and a Cache-Control header', async () => {
+    const entities = [
+      { LastSyncedUtc: new Date().toISOString() },
+      { LastSyncedUtc: new Date(Date.now() - 10 * 24 * 60 * 60 * 1000).toISOString() }
+    ];
+
+    getTableClient.mockReturnValue(createFakeTableClient(entities));
+
+    const context = createContext();
+    const req = { method: 'GET', headers: {} };
+
+    await actionsStatus(context, req);
+
+    expect(context.res.status).toBe(200);
+    expect(context.res.isRaw).toBe(true);
+    expect(context.res.headers['Cache-Control']).toBe('public, max-age=300');
+
+    const body = JSON.parse(context.res.body);
+    expect(body.totalCount).toBe(2);
+    expect(body.ageDistribution.within1day).toBe(1);
+    expect(body.ageDistribution.within30days).toBe(1);
+  });
+
+  it('handles OPTIONS request', async () => {
+    const context = createContext();
+    const req = { method: 'OPTIONS', headers: {} };
+
+    await actionsStatus(context, req);
+
+    expect(context.res.status).toBe(204);
+    expect(context.res.headers['Allow']).toBe('GET,OPTIONS');
+    expect(context.res.headers['Cache-Control']).toBeUndefined();
+  });
+
+  it('rejects non-GET/OPTIONS methods', async () => {
+    const context = createContext();
+    const req = { method: 'POST', headers: {} };
+
+    await actionsStatus(context, req);
+
+    expect(context.res.status).toBe(405);
+    expect(context.res.body.error).toBe('Method not allowed.');
+    expect(context.res.headers['Cache-Control']).toBeUndefined();
+  });
+
+  it('returns 500 without a Cache-Control header when the table query fails', async () => {
+    const fakeClient = {
+      url: 'http://127.0.0.1:10002/devstoreaccount1/actions',
+      async *listEntities() {
+        throw new Error('connection refused');
+      },
+      async getEntity() {
+        const err = new Error('Not Found');
+        err.statusCode = 404;
+        throw err;
+      }
+    };
+    getTableClient.mockReturnValue(fakeClient);
+
+    const context = createContext();
+    const req = { method: 'GET', headers: {} };
+
+    await actionsStatus(context, req);
+
+    expect(context.res.status).toBe(500);
+    expect(context.res.body.error).toBe('Failed to compute status.');
+    expect(context.res.headers['Cache-Control']).toBeUndefined();
+  });
+});

--- a/src/backend/tests/cacheHeaders.test.js
+++ b/src/backend/tests/cacheHeaders.test.js
@@ -1,0 +1,12 @@
+const { cacheControlHeaders } = require('../lib/cacheHeaders');
+
+describe('cacheControlHeaders', () => {
+  it('builds a public max-age Cache-Control header for the given TTL', () => {
+    expect(cacheControlHeaders(300)).toEqual({ 'Cache-Control': 'public, max-age=300' });
+  });
+
+  it('supports different TTLs per endpoint', () => {
+    expect(cacheControlHeaders(600)).toEqual({ 'Cache-Control': 'public, max-age=600' });
+    expect(cacheControlHeaders(1800)).toEqual({ 'Cache-Control': 'public, max-age=1800' });
+  });
+});


### PR DESCRIPTION
## Summary

All backend GET endpoints returned responses without a `Cache-Control` header, so browsers/CDNs couldn't cache them and every page load fired a fresh request against the API.

This adds a small shared helper, `cacheControlHeaders(maxAgeSeconds)` in `src/backend/lib/cacheHeaders.js`, and applies it to the **successful (2xx) response only** of each read endpoint. Error responses (4xx/5xx) are left uncached so clients always revalidate them.

TTLs chosen per the issue:

| Endpoint | Cache-Control |
|---|---|
| `ActionsList` | `public, max-age=300` (5 min) |
| `ActionsStats` | `public, max-age=300` (5 min) |
| `ActionsStatus` | `public, max-age=300` (5 min) |
| `ActionsGet` | `public, max-age=600` (10 min) |
| `ActionsReadme` | `public, max-age=1800` (30 min) |

`src/backend/lib/cors.js` was left untouched (it's purely about CORS headers); the new cache helper is merged into each endpoint's `headers` object alongside `withCorsHeaders(...)`, mirroring the pattern already used for `Content-Type`/`X-*` headers.

## Testing

- Added `src/backend/tests/cacheHeaders.test.js` for the new helper.
- Added `src/backend/tests/actionsStatus.test.js` (this endpoint had no test coverage at all previously) including a check that the 500 error path has no `Cache-Control` header.
- Added `Cache-Control` assertions to the existing success-path tests in `actionsList.test.js`, `actionsGet.test.js`, `actionsReadme.test.js`, and `actionsStats.test.js`, plus assertions that error paths omit the header.
- `npm test` in `src/backend`: 17 suites / 223 tests passing.
- `npm run lint` in `src/backend` currently fails on `main` (before this change too) because `eslint` was recently bumped to v10.7.0, which requires a flat `eslint.config.js`, while the repo still ships `.eslintrc.json`. Verified via `git stash` that this is a pre-existing issue unrelated to this PR. No lint-relevant code changes were made otherwise (kept style consistent with surrounding code).

Closes #174