### PR TITLE
refactor: centralise partition/row key normalisation logic

### DIFF
--- a/src/backend/ActionsGet/index.js
+++ b/src/backend/ActionsGet/index.js
@@ -2,6 +2,7 @@ const { ActionRecord } = require('../lib/actionRecord');
 const { getActionEntity } = require('../lib/tableStorage');
 const { withCorsHeaders } = require('../lib/cors');
 const { cacheControlHeaders } = require('../lib/cacheHeaders');
+const { normalizePartitionKey, normalizeRowKey } = require('../lib/keyUtils');
 
 const CACHE_MAX_AGE_SECONDS = 600; // 10 minutes
 
@@ -42,8 +43,8 @@ module.exports = async function actionsGet(context, req) {
     return;
   }
 
-  const partitionKey = ActionRecord.normalizeKey(owner);
-  const rowKey = ActionRecord.normalizeKey(name);
+  const partitionKey = normalizePartitionKey(owner);
+  const rowKey = normalizeRowKey(name);
   // Some records were ingested with rowKey = "{owner}_{name}"; fall back to that format.
   const rowKeyFallback = `${partitionKey}_${rowKey}`;
 

--- a/src/backend/ActionsList/index.js
+++ b/src/backend/ActionsList/index.js
@@ -2,6 +2,7 @@ const { getTableClient } = require('../lib/tableStorage');
 const { ActionRecord } = require('../lib/actionRecord');
 const { withCorsHeaders } = require('../lib/cors');
 const { cacheControlHeaders } = require('../lib/cacheHeaders');
+const { normalizePartitionKey } = require('../lib/keyUtils');
 
 const CACHE_MAX_AGE_SECONDS = 300; // 5 minutes
 
@@ -89,7 +90,7 @@ module.exports = async function actionsList(context, req) {
     
     if (owner) {
       // Sanitize owner to prevent OData injection - escape single quotes first, then normalize case
-      const sanitizedOwner = String(owner).replace(/'/g, "''").toLowerCase();
+      const sanitizedOwner = normalizePartitionKey(String(owner).replace(/'/g, "''"));
       queryOptions = { queryOptions: { filter: `PartitionKey eq '${sanitizedOwner}'` } };
     }
     

--- a/src/backend/ActionsReadme/index.js
+++ b/src/backend/ActionsReadme/index.js
@@ -5,6 +5,7 @@ const { getActionEntity } = require('../lib/tableStorage');
 const { ActionRecord } = require('../lib/actionRecord');
 const { extractRepoName } = require('../lib/actionNameDecoder');
 const { cacheControlHeaders } = require('../lib/cacheHeaders');
+const { normalizePartitionKey, normalizeRowKey } = require('../lib/keyUtils');
 
 const CACHE_MAX_AGE_SECONDS = 1800; // 30 minutes
 
@@ -49,8 +50,8 @@ async function fetchReadmeFromGitHub(owner, name, version) {
 }
 
 async function getRepoUpdatedAt(owner, name) {
-  const partitionKey = ActionRecord.normalizeKey(owner);
-  const rowKey = ActionRecord.normalizeKey(name);
+  const partitionKey = normalizePartitionKey(owner);
+  const rowKey = normalizeRowKey(name);
   
   try {
     const entity = await getActionEntity(partitionKey, rowKey);

--- a/src/backend/client/index.js
+++ b/src/backend/client/index.js
@@ -1,6 +1,7 @@
 const { ActionRecord } = require('../lib/actionRecord');
 const { createTableClient } = require('../lib/tableStorage');
 const { MarketplaceApiError } = require('../lib/errors');
+const { normalizePartitionKey } = require('../lib/keyUtils');
 
 class ActionsMarketplaceClient {
   constructor(options = {}) {
@@ -228,7 +229,7 @@ class ActionsMarketplaceClient {
       
       if (owner) {
         // Sanitize owner to prevent OData injection - escape single quotes first, then normalize case
-        const sanitizedOwner = String(owner).replace(/'/g, "''").toLowerCase();
+        const sanitizedOwner = normalizePartitionKey(String(owner).replace(/'/g, "''"));
         queryOptions = { queryOptions: { filter: `PartitionKey eq '${sanitizedOwner}'` } };
       }
       

--- a/src/backend/lib/actionRecord.js
+++ b/src/backend/lib/actionRecord.js
@@ -1,4 +1,5 @@
 const crypto = require('crypto');
+const { normalizePartitionKey, normalizeRowKey } = require('./keyUtils');
 
 class ActionRecord {
   constructor(raw, canonicalJson, hash, partitionKey, rowKey) {
@@ -23,8 +24,8 @@ class ActionRecord {
     const canonicalJson = ActionRecord.canonicalize(sanitized);
     const hash = ActionRecord.hashPayload(canonicalJson);
 
-    const partitionKey = ActionRecord.normalizeKey(owner);
-    const rowKey = ActionRecord.normalizeKey(name);
+    const partitionKey = normalizePartitionKey(owner);
+    const rowKey = normalizeRowKey(name);
 
     return new ActionRecord({ ...sanitized, owner, name }, canonicalJson, hash, partitionKey, rowKey);
   }
@@ -51,10 +52,6 @@ class ActionRecord {
       throw new Error(`Missing required field: ${fieldName}`);
     }
     return value;
-  }
-
-  static normalizeKey(value) {
-    return String(value).trim().toLowerCase();
   }
 
   static sortValue(value) {
@@ -107,8 +104,8 @@ class ActionRecord {
 
     const canonicalJson = ActionRecord.canonicalize(sanitized);
     const expectedHash = entity.PayloadHash || ActionRecord.hashPayload(canonicalJson);
-    const partitionKey = entity.partitionKey || entity.PartitionKey || ActionRecord.normalizeKey(owner);
-    const rowKey = entity.rowKey || entity.RowKey || ActionRecord.normalizeKey(name);
+    const partitionKey = entity.partitionKey || entity.PartitionKey || normalizePartitionKey(owner);
+    const rowKey = entity.rowKey || entity.RowKey || normalizeRowKey(name);
 
     return new ActionRecord({ ...sanitized, owner, name }, canonicalJson, expectedHash, partitionKey, rowKey);
   }

--- a/src/backend/lib/keyUtils.js
+++ b/src/backend/lib/keyUtils.js
@@ -1,0 +1,32 @@
+/**
+ * Shared helpers for normalizing values used as Azure Table Storage
+ * partition/row keys. Centralizing this logic avoids subtle lookup
+ * mismatches caused by inconsistent normalization across modules.
+ */
+
+function normalize(value) {
+  return String(value).trim().toLowerCase();
+}
+
+/**
+ * Normalizes a value (typically an owner) for use as a partition key.
+ * @param {*} owner
+ * @returns {string}
+ */
+function normalizePartitionKey(owner) {
+  return normalize(owner);
+}
+
+/**
+ * Normalizes a value (typically a name or version) for use as a row key.
+ * @param {*} name
+ * @returns {string}
+ */
+function normalizeRowKey(name) {
+  return normalize(name);
+}
+
+module.exports = {
+  normalizePartitionKey,
+  normalizeRowKey
+};

--- a/src/backend/lib/readmeCache.js
+++ b/src/backend/lib/readmeCache.js
@@ -1,4 +1,5 @@
 const { createTableClient } = require('./tableStorage');
+const { normalizePartitionKey, normalizeRowKey } = require('./keyUtils');
 
 const readmeTableName = process.env.README_TABLE_NAME || 'readmes';
 
@@ -14,14 +15,14 @@ function getReadmeTableClient(options = {}) {
  * Uses the same normalization as action records
  */
 function getReadmePartitionKey(owner, name) {
-  return `${owner.toLowerCase()}-${name.toLowerCase()}`;
+  return `${normalizePartitionKey(owner)}-${normalizeRowKey(name)}`;
 }
 
 /**
  * Creates a row key for README storage based on version
  */
 function getReadmeRowKey(version) {
-  return (version || 'main').toLowerCase();
+  return normalizeRowKey(version || 'main');
 }
 
 /**

--- a/src/backend/tests/keyUtils.test.js
+++ b/src/backend/tests/keyUtils.test.js
@@ -1,0 +1,28 @@
+const { normalizePartitionKey, normalizeRowKey } = require('../lib/keyUtils');
+
+describe('keyUtils', () => {
+  describe('normalizePartitionKey', () => {
+    it('lower-cases and trims the value', () => {
+      expect(normalizePartitionKey('  Actions  ')).toBe('actions');
+    });
+
+    it('coerces non-string values to strings', () => {
+      expect(normalizePartitionKey(123)).toBe('123');
+    });
+  });
+
+  describe('normalizeRowKey', () => {
+    it('lower-cases and trims the value', () => {
+      expect(normalizeRowKey('  CheckOut\t')).toBe('checkout');
+    });
+
+    it('coerces non-string values to strings', () => {
+      expect(normalizeRowKey(456)).toBe('456');
+    });
+  });
+
+  it('produces identical output for equivalent partition and row key inputs', () => {
+    const value = '  My-Org  ';
+    expect(normalizePartitionKey(value)).toBe(normalizeRowKey(value));
+  });
+});


### PR DESCRIPTION
## Summary

Partition/row key normalisation (trimming and lower-casing owner/name/version strings used as Azure Table Storage keys) was duplicated across several backend files, risking subtle lookup mismatches if the logic ever drifted between call sites.

This PR extracts the logic into a single shared module, `src/backend/lib/keyUtils.js`:

```js
function normalizePartitionKey(owner) {
  return String(owner).trim().toLowerCase();
}
function normalizeRowKey(name) {
  return String(name).trim().toLowerCase();
}
```

## Call sites updated

- `src/backend/lib/actionRecord.js` — removed the `ActionRecord.normalizeKey` static method (previously `String(value).trim().toLowerCase()`); `fromRequest` and `fromEntity` now call `normalizePartitionKey`/`normalizeRowKey` directly.
- `src/backend/lib/readmeCache.js` — `getReadmePartitionKey` and `getReadmeRowKey` now delegate to the shared helpers instead of inlining `owner.toLowerCase()` / `name.toLowerCase()` / `(version || 'main').toLowerCase()`.
- `src/backend/ActionsGet/index.js` — replaced `ActionRecord.normalizeKey(owner)` / `ActionRecord.normalizeKey(name)` with `normalizePartitionKey`/`normalizeRowKey`.
- `src/backend/ActionsReadme/index.js` — same replacement in `getRepoUpdatedAt`.
- `src/backend/ActionsList/index.js` — the OData filter's `sanitizedOwner` now normalises case via `normalizePartitionKey` after escaping single quotes (previously an inline `.toLowerCase()`).
- `src/backend/client/index.js` — same change in `_listViaTable`'s OData filter construction.

Behavior is unchanged at every site except that owner/name values used to build the README cache keys and the OData `PartitionKey` filter are now also trimmed (previously only lower-cased), matching the normalisation already used when the keys were originally written via `ActionRecord`. This closes the "subtle lookup mismatch" gap described in the issue.

## Test plan

- [x] Added `src/backend/tests/keyUtils.test.js` covering `normalizePartitionKey`/`normalizeRowKey` (trimming, lower-casing, non-string coercion).
- [x] `npm test` in `src/backend` — 16 suites / 222 tests passing.
- [x] `npm run lint` in `src/backend` — pre-existing failure unrelated to this change (ESLint 10.7.0 requires flat `eslint.config.js`, repo still has `.eslintrc.json`); confirmed this fails identically on `main` without any of these changes, so left out of scope for this PR.

Closes #172