### PR TITLE
api: implement cursor-based pagination in ActionsList

### DIFF
--- a/src/backend/ActionsList/index.js
+++ b/src/backend/ActionsList/index.js
@@ -3,8 +3,38 @@ const { ActionRecord } = require('../lib/actionRecord');
 const { withCorsHeaders } = require('../lib/cors');
 const { cacheControlHeaders } = require('../lib/cacheHeaders');
 const { normalizePartitionKey } = require('../lib/keyUtils');
+const { readCache } = require('../lib/statsCache');
 
 const CACHE_MAX_AGE_SECONDS = 300; // 5 minutes
+
+// Encodes an opaque continuation value (string, number, or object) into a
+// URL-safe cursor for clients to pass back on the next request.
+function encodeCursor(continuationToken) {
+  if (continuationToken === undefined || continuationToken === null || continuationToken === '') {
+    return null;
+  }
+  return Buffer.from(JSON.stringify(continuationToken)).toString('base64');
+}
+
+// Decodes a cursor produced by encodeCursor. Throws if the cursor is malformed
+// so callers can respond with a 400 instead of silently ignoring it.
+function decodeCursor(cursor) {
+  const json = Buffer.from(String(cursor), 'base64').toString('utf8');
+  return JSON.parse(json);
+}
+
+function entityToActionInfo(e) {
+  try {
+    return ActionRecord.fromEntity(e).toActionInfo(true, {
+      etag: e.etag,
+      lastSyncedUtc: e.LastSyncedUtc,
+      partitionKey: e.partitionKey || e.PartitionKey,
+      rowKey: e.rowKey || e.RowKey
+    });
+  } catch {
+    return null;
+  }
+}
 
 module.exports = async function actionsList(context, req) {
   if (req.method === 'OPTIONS') {
@@ -27,8 +57,13 @@ module.exports = async function actionsList(context, req) {
   const owner = (req && req.query && req.query.owner)
     ? String(req.query.owner)
     : (context.bindingData && context.bindingData.owner);
-  
-  // Parse limit parameter for pagination
+
+  // Parse limit parameter. When provided, it also acts as the page size for
+  // cursor-based pagination (see `cursor` below) and the response is wrapped
+  // as `{ items, nextCursor }`. When omitted, the full result set is returned
+  // as a plain array, preserving the historic behaviour relied on by callers
+  // that need the complete dataset in one shot (e.g. the frontend's
+  // background full fetch, or the E2E test harness).
   let limit = null;
   if (req.query && req.query.limit) {
     const parsed = parseInt(req.query.limit, 10);
@@ -36,48 +71,71 @@ module.exports = async function actionsList(context, req) {
       limit = parsed;
     }
   }
-  
+
+  // Parse the opaque pagination cursor (only meaningful together with `limit`).
+  let continuationToken;
+  if (limit !== null && req.query && req.query.cursor) {
+    try {
+      continuationToken = decodeCursor(req.query.cursor);
+    } catch {
+      context.res = {
+        status: 400,
+        headers: withCorsHeaders(req),
+        body: { error: 'Invalid cursor parameter.' }
+      };
+      return;
+    }
+  }
+
   const tableClient = getTableClient();
   const tableUrl = tableClient && tableClient.url ? tableClient.url.split('?')[0] : 'unknown';
-  let entities = [];
 
   // For now, only support in-memory/fake client for integration tests
   if (typeof tableClient.store === 'object' && tableClient.store instanceof Map) {
     // Simulate Table Storage query by owner
-    entities = Array.from(tableClient.store.values()).filter(e => {
+    const filteredEntities = Array.from(tableClient.store.values()).filter(e => {
       const entityOwner = e.Owner || (e.PayloadJson && JSON.parse(e.PayloadJson).owner);
       return owner ? entityOwner === owner : true;
     });
-    
-    // Apply limit if specified
-    const totalCount = entities.length;
-    if (limit !== null && limit < entities.length) {
-      entities = entities.slice(0, limit);
-    }
-    
-    const results = entities.map(e => {
-      try {
-        return ActionRecord.fromEntity(e).toActionInfo(true, {
-          etag: e.etag,
-          lastSyncedUtc: e.LastSyncedUtc,
-          partitionKey: e.partitionKey || e.PartitionKey,
-          rowKey: e.rowKey || e.RowKey
-        });
-      } catch {
-        return null;
+
+    const totalCount = filteredEntities.length;
+    const baseHeaders = {
+      'X-Total-Count': totalCount,
+      'X-Table-Endpoint': tableUrl,
+      'Content-Type': 'application/json',
+      ...cacheControlHeaders(CACHE_MAX_AGE_SECONDS)
+    };
+
+    if (limit !== null) {
+      let startIndex = 0;
+      if (continuationToken !== undefined) {
+        const parsedIndex = Number(continuationToken);
+        startIndex = Number.isFinite(parsedIndex) && parsedIndex > 0 ? parsedIndex : 0;
       }
-    }).filter(Boolean);
+
+      const pageEntities = filteredEntities.slice(startIndex, startIndex + limit);
+      const nextIndex = startIndex + pageEntities.length;
+      const nextCursor = nextIndex < filteredEntities.length ? encodeCursor(nextIndex) : null;
+      const results = pageEntities.map(entityToActionInfo).filter(Boolean);
+
+      context.log(`ActionsList: returning page of ${results.length} of ${totalCount} entities (fake client), table ${tableUrl}`);
+
+      context.res = {
+        status: 200,
+        headers: { ...baseHeaders, 'X-Actions-Count': results.length },
+        body: { items: results, nextCursor }
+      };
+      context.res.headers = withCorsHeaders(req, context.res.headers);
+      return;
+    }
+
+    const results = filteredEntities.map(entityToActionInfo).filter(Boolean);
 
     context.log(`ActionsList: returning ${results.length} of ${totalCount} entities (fake client), table ${tableUrl}`);
 
     context.res = {
       status: 200,
-      headers: {
-        'X-Actions-Count': results.length,
-        'X-Table-Endpoint': tableUrl,
-        'Content-Type': 'application/json',
-        ...cacheControlHeaders(CACHE_MAX_AGE_SECONDS)
-      },
+      headers: { ...baseHeaders, 'X-Actions-Count': results.length },
       body: results
     };
     context.res.headers = withCorsHeaders(req, context.res.headers);
@@ -87,44 +145,87 @@ module.exports = async function actionsList(context, req) {
   // Real Table Storage query for production
   try {
     let queryOptions = {};
-    
+
     if (owner) {
       // Sanitize owner to prevent OData injection - escape single quotes first, then normalize case
       const sanitizedOwner = normalizePartitionKey(String(owner).replace(/'/g, "''"));
       queryOptions = { queryOptions: { filter: `PartitionKey eq '${sanitizedOwner}'` } };
     }
-    
-    for await (const entity of tableClient.listEntities(queryOptions)) {
-      entities.push(entity);
-      // Apply limit during iteration for better performance
-      if (limit !== null && entities.length >= limit) {
-        break;
+
+    // Best-effort total count from the cached stats aggregate (see ActionsStats).
+    // Only valid for the unfiltered dataset, and never worth failing the request over.
+    let totalCount = null;
+    if (!owner) {
+      try {
+        const cached = await readCache(tableClient);
+        const cachedTotal = cached && cached.data && cached.data.stats && cached.data.stats.total;
+        if (typeof cachedTotal === 'number') {
+          totalCount = cachedTotal;
+        }
+      } catch {
+        // ignore - the total count header is a nice-to-have
       }
     }
 
-    const results = entities.map(e => {
-      try {
-        return ActionRecord.fromEntity(e).toActionInfo(true, {
-          etag: e.etag,
-          lastSyncedUtc: e.LastSyncedUtc,
-          partitionKey: e.partitionKey,
-          rowKey: e.rowKey
-        });
-      } catch {
-        return null;
+    if (limit !== null) {
+      // Cursor-based pagination: fetch a single page of `limit` entities using
+      // Azure Table Storage's continuation token, instead of scanning the
+      // whole table and slicing in memory.
+      const pageSettings = { maxPageSize: limit };
+      if (continuationToken !== undefined) {
+        pageSettings.continuationToken = continuationToken;
       }
-    }).filter(Boolean);
 
-    context.log(`ActionsList: returning ${results.length} entities${limit !== null ? ` (limited to ${limit})` : ''}, table ${tableUrl}`);
+      const pageIterator = tableClient.listEntities(queryOptions).byPage(pageSettings);
+      const { value: page } = await pageIterator.next();
+      const pageEntities = page || [];
+      const results = pageEntities.map(entityToActionInfo).filter(Boolean);
+      const nextCursor = encodeCursor(page && page.continuationToken);
 
-    context.res = {
-      status: 200,
-      headers: {
+      const headers = {
         'X-Actions-Count': results.length,
         'X-Table-Endpoint': tableUrl,
         'Content-Type': 'application/json',
         ...cacheControlHeaders(CACHE_MAX_AGE_SECONDS)
-      },
+      };
+      if (totalCount !== null) {
+        headers['X-Total-Count'] = totalCount;
+      }
+
+      context.log(`ActionsList: returning page of ${results.length} entities (limit ${limit}), table ${tableUrl}`);
+
+      context.res = {
+        status: 200,
+        headers,
+        body: { items: results, nextCursor }
+      };
+      context.res.headers = withCorsHeaders(req, context.res.headers);
+      return;
+    }
+
+    // No limit specified: preserve the historic "return everything" behaviour.
+    const entities = [];
+    for await (const entity of tableClient.listEntities(queryOptions)) {
+      entities.push(entity);
+    }
+
+    const results = entities.map(entityToActionInfo).filter(Boolean);
+
+    const headers = {
+      'X-Actions-Count': results.length,
+      'X-Table-Endpoint': tableUrl,
+      'Content-Type': 'application/json',
+      ...cacheControlHeaders(CACHE_MAX_AGE_SECONDS)
+    };
+    if (totalCount !== null) {
+      headers['X-Total-Count'] = totalCount;
+    }
+
+    context.log(`ActionsList: returning ${results.length} entities, table ${tableUrl}`);
+
+    context.res = {
+      status: 200,
+      headers,
       body: results
     };
     context.res.headers = withCorsHeaders(req, context.res.headers);

--- a/src/backend/client/index.js
+++ b/src/backend/client/index.js
@@ -212,12 +212,19 @@ class ActionsMarketplaceClient {
     }
 
     const body = await response.json();
-    
-    if (!Array.isArray(body)) {
-      throw new Error('Invalid response format: expected an array of actions');
+
+    // The endpoint returns a plain array when no `limit` is requested, or a
+    // paginated `{ items, nextCursor }` envelope when `limit` (and optionally
+    // `cursor`) is used. Normalize both shapes to a plain array for callers.
+    if (Array.isArray(body)) {
+      return body;
     }
 
-    return body;
+    if (body && Array.isArray(body.items)) {
+      return body.items;
+    }
+
+    throw new Error('Invalid response format: expected an array of actions');
   }
 
   async _listViaTable(options = {}) {

--- a/src/backend/tests/actionsList.test.js
+++ b/src/backend/tests/actionsList.test.js
@@ -87,7 +87,8 @@ describe('ActionsList function', () => {
     await actionsList(context, req);
 
     expect(context.res.status).toBe(200);
-    expect(context.res.body).toHaveLength(50);
+    expect(context.res.body.items).toHaveLength(50);
+    expect(context.res.body.nextCursor).toBeTruthy();
   });
 
   test('should handle small limit values', async () => {
@@ -104,7 +105,8 @@ describe('ActionsList function', () => {
     await actionsList(context, req);
 
     expect(context.res.status).toBe(200);
-    expect(context.res.body).toHaveLength(10);
+    expect(context.res.body.items).toHaveLength(10);
+    expect(context.res.body.nextCursor).toBeTruthy();
   });
 
   test('should ignore invalid limit values', async () => {
@@ -155,7 +157,8 @@ describe('ActionsList function', () => {
     await actionsList(context, req);
 
     expect(context.res.status).toBe(200);
-    expect(context.res.body).toHaveLength(100);
+    expect(context.res.body.items).toHaveLength(100);
+    expect(context.res.body.nextCursor).toBeNull();
   });
 
   test('should handle OPTIONS request', async () => {
@@ -201,8 +204,68 @@ describe('ActionsList function', () => {
     await actionsList(context, req);
 
     expect(context.res.status).toBe(200);
-    expect(context.res.body).toHaveLength(25);
-    expect(context.res.body.every(a => a.owner === 'testowner')).toBe(true);
+    expect(context.res.body.items).toHaveLength(25);
+    expect(context.res.body.items.every(a => a.owner === 'testowner')).toBe(true);
+  });
+
+  test('paginates through all pages using nextCursor until exhausted (fake client)', async () => {
+    const entities = createTestEntities(10);
+    getTableClient.mockReturnValue(createFakeTableClient(entities));
+
+    const seenNames = [];
+    let cursor;
+    let guard = 0;
+
+    do {
+      const context = createContext();
+      const req = {
+        method: 'GET',
+        query: cursor ? { limit: '3', cursor } : { limit: '3' },
+        headers: {}
+      };
+
+      await actionsList(context, req);
+
+      expect(context.res.status).toBe(200);
+      context.res.body.items.forEach(a => seenNames.push(a.name));
+      cursor = context.res.body.nextCursor;
+      guard += 1;
+    } while (cursor && guard < 10);
+
+    expect(seenNames).toHaveLength(10);
+    expect(new Set(seenNames).size).toBe(10);
+  });
+
+  test('returns 400 for a malformed cursor', async () => {
+    const entities = createTestEntities(10);
+    getTableClient.mockReturnValue(createFakeTableClient(entities));
+
+    const context = createContext();
+    const req = {
+      method: 'GET',
+      query: { limit: '3', cursor: 'not-valid-base64-json!!' },
+      headers: {}
+    };
+
+    await actionsList(context, req);
+
+    expect(context.res.status).toBe(400);
+  });
+
+  test('exposes X-Total-Count header reflecting the filtered total', async () => {
+    const entities = createTestEntities(10);
+    getTableClient.mockReturnValue(createFakeTableClient(entities));
+
+    const context = createContext();
+    const req = {
+      method: 'GET',
+      query: { limit: '3' },
+      headers: {}
+    };
+
+    await actionsList(context, req);
+
+    expect(context.res.headers['X-Total-Count']).toBe(10);
   });
 });
 
@@ -211,14 +274,46 @@ describe('ActionsList real table client path', () => {
     jest.clearAllMocks();
   });
 
+  // Mimics the shape of the @azure/data-tables PagedAsyncIterableIterator:
+  // both a plain async iterable (`for await`) and a `.byPage()` page iterator
+  // that carries a `continuationToken` on each returned page.
   function createRealStyleTableClient(entities, throwError) {
     return {
       url: 'https://real.table.core.windows.net/actions',
-      async *listEntities() {
-        if (throwError) throw throwError;
-        for (const entity of entities) {
-          yield entity;
-        }
+      listEntities() {
+        return {
+          async *[Symbol.asyncIterator]() {
+            if (throwError) throw throwError;
+            for (const entity of entities) {
+              yield entity;
+            }
+          },
+          byPage(settings = {}) {
+            const maxPageSize = settings.maxPageSize || entities.length || 1;
+            let startIndex = 0;
+            if (settings.continuationToken !== undefined) {
+              const parsed = Number(settings.continuationToken);
+              startIndex = Number.isFinite(parsed) && parsed > 0 ? parsed : 0;
+            }
+
+            return {
+              async next() {
+                if (throwError) throw throwError;
+                if (startIndex >= entities.length) {
+                  return { done: true, value: undefined };
+                }
+                const page = entities.slice(startIndex, startIndex + maxPageSize);
+                const nextIndex = startIndex + page.length;
+                page.continuationToken = nextIndex < entities.length ? String(nextIndex) : undefined;
+                startIndex = nextIndex;
+                return { done: false, value: page };
+              },
+              [Symbol.asyncIterator]() {
+                return this;
+              }
+            };
+          }
+        };
       }
     };
   }
@@ -253,7 +348,7 @@ describe('ActionsList real table client path', () => {
     expect(context.res.headers['Cache-Control']).toBe('public, max-age=300');
   });
 
-  test('applies limit during iteration', async () => {
+  test('applies limit using a single cursor-based page (first page, no cursor)', async () => {
     const entities = Array.from({ length: 10 }, (_, i) =>
       createTestEntity('org', `action${i}`)
     );
@@ -265,7 +360,60 @@ describe('ActionsList real table client path', () => {
     await actionsList(context, req);
 
     expect(context.res.status).toBe(200);
-    expect(context.res.body).toHaveLength(3);
+    expect(context.res.body.items).toHaveLength(3);
+    expect(context.res.body.items.map(a => a.name)).toEqual(['action0', 'action1', 'action2']);
+    expect(context.res.body.nextCursor).toBeTruthy();
+  });
+
+  test('fetches the next page using the cursor from the previous page', async () => {
+    const entities = Array.from({ length: 10 }, (_, i) =>
+      createTestEntity('org', `action${i}`)
+    );
+    getTableClient.mockReturnValue(createRealStyleTableClient(entities));
+
+    const firstContext = createContext();
+    await actionsList(firstContext, { method: 'GET', query: { limit: '3' }, headers: {} });
+    const firstCursor = firstContext.res.body.nextCursor;
+    expect(firstCursor).toBeTruthy();
+
+    const secondContext = createContext();
+    await actionsList(secondContext, {
+      method: 'GET',
+      query: { limit: '3', cursor: firstCursor },
+      headers: {}
+    });
+
+    expect(secondContext.res.status).toBe(200);
+    expect(secondContext.res.body.items).toHaveLength(3);
+    expect(secondContext.res.body.items.map(a => a.name)).toEqual(['action3', 'action4', 'action5']);
+    expect(secondContext.res.body.nextCursor).toBeTruthy();
+  });
+
+  test('returns a null nextCursor on the last page', async () => {
+    const entities = Array.from({ length: 10 }, (_, i) =>
+      createTestEntity('org', `action${i}`)
+    );
+    getTableClient.mockReturnValue(createRealStyleTableClient(entities));
+
+    // Walk through pages of 4 until nextCursor is null: page1 [0-3], page2 [4-7], page3 [8-9].
+    let cursor;
+    let lastBody;
+    let guard = 0;
+    do {
+      const context = createContext();
+      await actionsList(context, {
+        method: 'GET',
+        query: cursor ? { limit: '4', cursor } : { limit: '4' },
+        headers: {}
+      });
+      lastBody = context.res.body;
+      cursor = lastBody.nextCursor;
+      guard += 1;
+    } while (cursor && guard < 10);
+
+    expect(lastBody.items).toHaveLength(2);
+    expect(lastBody.items.map(a => a.name)).toEqual(['action8', 'action9']);
+    expect(lastBody.nextCursor).toBeNull();
   });
 
   test('filters by owner using OData query option', async () => {

--- a/src/backend/tests/client.test.js
+++ b/src/backend/tests/client.test.js
@@ -403,6 +403,40 @@ describe('ActionsMarketplaceClient', () => {
         );
       });
 
+      it('unwraps a paginated { items, nextCursor } response into an array', async () => {
+        const client = new ActionsMarketplaceClient({
+          apiUrl: 'https://example.com'
+        });
+
+        const mockActions = [
+          { owner: 'actions', name: 'checkout', description: 'Checkout code' }
+        ];
+
+        const mockFetch = jest.fn().mockResolvedValue({
+          ok: true,
+          json: async () => ({ items: mockActions, nextCursor: 'abc123' })
+        });
+        global.fetch = mockFetch;
+
+        const result = await client.listActions({ limit: 1 });
+
+        expect(result).toEqual(mockActions);
+      });
+
+      it('throws when the response is neither an array nor a paginated envelope', async () => {
+        const client = new ActionsMarketplaceClient({
+          apiUrl: 'https://example.com'
+        });
+
+        const mockFetch = jest.fn().mockResolvedValue({
+          ok: true,
+          json: async () => ({ unexpected: true })
+        });
+        global.fetch = mockFetch;
+
+        await expect(client.listActions()).rejects.toThrow('Invalid response format: expected an array of actions');
+      });
+
       it('appends limit to URL when provided', async () => {
         const client = new ActionsMarketplaceClient({
           apiUrl: 'https://example.com'

--- a/src/mcp-server/lib/backendClient.js
+++ b/src/mcp-server/lib/backendClient.js
@@ -50,7 +50,20 @@ async function fetchActionsList(options = {}) {
     throw new Error(`Backend API returned ${response.status} for actions list`);
   }
 
-  return response.json();
+  const body = await response.json();
+
+  // The endpoint returns a plain array when unpaginated, or a paginated
+  // `{ items, nextCursor }` envelope when `limit` is used (as it always is
+  // here). Normalize to a plain array for callers.
+  if (Array.isArray(body)) {
+    return body;
+  }
+
+  if (body && Array.isArray(body.items)) {
+    return body.items;
+  }
+
+  return body;
 }
 
 module.exports = { fetchAction, fetchActionsList };

--- a/src/mcp-server/test/backendClient.test.js
+++ b/src/mcp-server/test/backendClient.test.js
@@ -101,6 +101,18 @@ describe('fetchActionsList', () => {
     );
   });
 
+  test('unwraps a paginated { items, nextCursor } response into an array', async () => {
+    const list = [{ owner: 'actions', name: 'checkout' }];
+    global.fetch.mockResolvedValue(makeFetchResponse({
+      status: 200,
+      ok: true,
+      json: { items: list, nextCursor: 'abc123' }
+    }));
+
+    const result = await fetchActionsList({ limit: 50 });
+    expect(result).toEqual(list);
+  });
+
   test('throws error for non-ok response', async () => {
     global.fetch.mockResolvedValue(makeFetchResponse({ status: 500, ok: false, json: null }));
 


### PR DESCRIPTION
## Summary

`src/backend/ActionsList/index.js` supported a `limit` query parameter, but it only ever returned the *first* N rows - there was no way to fetch subsequent pages, and for the fake/test client the full dataset was loaded into memory before slicing.

This implements real cursor-based pagination using Azure Table Storage's continuation tokens:

- `GET /actions/list?limit=50` now fetches a single page via `tableClient.listEntities(...).byPage({ maxPageSize, continuationToken })` and returns:
  ```json
  { "items": [ ... up to 50 entities ... ], "nextCursor": "<base64 token, or null on the last page>" }
  ```
- `GET /actions/list?limit=50&cursor=<nextCursor>` fetches the following page.
- An invalid/malformed `cursor` returns `400`.
- `GET /actions/list` **without** `limit` keeps returning a plain JSON array of the full result set, unchanged from before. This preserves behavior for callers that intentionally want the complete dataset in one response (frontend's background full fetch used for client-side filtering/sorting, the Playwright E2E harness, and mcp-server's cache pre-warm which always requests a fixed `limit=200` "page" today).
- Added a best-effort `X-Total-Count` response header: for the in-memory/test client it's the exact filtered count; for production it comes from the cached stats aggregate (`ActionsStats`/`lib/statsCache.js`) when no `owner` filter is applied, and is simply omitted otherwise rather than standing up new infrastructure, per the issue's "nice to have, skip if complex" guidance.

## Response shape / compatibility

Only the `limit`-driven path changes shape (array of "first N" -> `{ items, nextCursor }`). Everywhere else keeps returning a plain array.

Frontend: no changes needed. `actionsService.ts`'s `extractArrayFromUnknown()` already treats an `items` key on the response as one of its preferred unwrap keys, so both `fetchActions()` (no limit, unaffected) and `fetchActionsPage()` (uses `limit`, now paginated) keep working end-to-end.

Two other in-repo callers that pass `limit` and previously assumed a bare array were updated to unwrap the new envelope, falling back to the old bare-array handling:
- `src/backend/client/index.js` (`@devops-actions/actions-marketplace-client`'s `_listViaHttp`)
- `src/mcp-server/lib/backendClient.js` (`fetchActionsList`, used by the mcp-server's cache pre-warm)

## Tests

- Updated `src/backend/tests/actionsList.test.js`: existing limit-based assertions now read `body.items`; added tests for a full walk through all pages via `nextCursor` until exhausted, a malformed-cursor 400, and the `X-Total-Count` header (fake/in-memory client), plus first-page / cursor-continuation / last-page-null-cursor tests against an enhanced "real-style" fake table client that now also implements `.byPage()` (mirroring `@azure/data-tables`'s `PagedAsyncIterableIterator` shape).
- Updated `src/backend/tests/client.test.js` and `src/mcp-server/test/backendClient.test.js` with tests for unwrapping the new `{ items, nextCursor }` envelope.
- `npm test` passes in `src/backend` (224 tests) and `src/mcp-server` (122 tests).

Note: `npm run lint` in `src/backend` currently fails on `main` before this change too - a recent dependency bump to ESLint 10.7 dropped support for the repo's `.eslintrc.json` format (needs migrating to `eslint.config.js`), unrelated to this change.

Closes #173