### PR TITLE
fix: lint-only fix for require-yield in actionsStatus.test.js

### DIFF
--- a/src/backend/tests/actionsStatus.test.js
+++ b/src/backend/tests/actionsStatus.test.js
@@ -91,6 +91,7 @@ describe('ActionsStatus function', () => {
   it('returns 500 without a Cache-Control header when the table query fails', async () => {
     const fakeClient = {
       url: 'http://127.0.0.1:10002/devstoreaccount1/actions',
+      // eslint-disable-next-line require-yield -- must stay an async generator to match the real client's iterable interface
       async *listEntities() {
         throw new Error('connection refused');
       },


### PR DESCRIPTION
## Summary
- `npm run lint` in `src/backend` was failing with `require-yield` on the error-path mock in `tests/actionsStatus.test.js` (introduced in #202), since `listEntities` was written as `async function*` but never yields — it throws immediately to simulate a table query failure.
- The mock must stay an async generator so it matches the real client's async-iterable interface (`for await (const entity of tableClient.listEntities())`), so this suppresses the rule for that line rather than dropping the `*`, matching the existing pattern already used in `tests/actionsStats.test.js`.
- Lint-only fix, no behavior change.

## Test plan
- [x] `npm run lint` in `src/backend` — passes with no errors
- [x] `npm test` in `src/backend` — 18 suites / 239 tests pass