### PR TITLE
fix: strip thousands separators before parsing dependents count

### DIFF
--- a/.github/instructions/dependents-count.instructions.md
+++ b/.github/instructions/dependents-count.instructions.md
@@ -1,0 +1,20 @@
+---
+applyTo: "src/frontend/src/services/actionsService.ts"
+---
+
+# Dependents / "used by" count parsing
+
+The `dependents` value coming from the API can be a **comma-formatted
+string** (e.g. `"15,356,161"`) or end with a `+` (e.g. `"999+"`). It
+originates from a regex-scrape of GitHub's `/network/dependents` page and is
+passed through unchanged by the backend and Azure Table Storage.
+
+`parseDependentsCount` / `formatDependentsCount` MUST strip thousands
+separators (commas) before calling `parseInt`/`Number`, otherwise the value
+silently truncates at the first comma (e.g. `parseInt("16,842,392", 10)` ===
+`16`). This was the root cause of the marketplace showing tiny "used by"
+numbers (e.g. `16`) for very popular actions like `actions/checkout`.
+
+Full investigation/debugging runbook for this class of bug lives in the
+sibling `actions-marketplace-checks` repo:
+`actions-marketplace-checks/DEPENDENTS-COUNT-DEBUGGING.md`.

--- a/src/frontend/src/services/actionsService.ts
+++ b/src/frontend/src/services/actionsService.ts
@@ -46,7 +46,11 @@ const API_BASE_URL = getApiBaseUrl();
 export function parseDependentsCount(value: string | undefined): number {
   if (!value) return 0;
   const isPlus = value.endsWith('+');
-  const num = parseInt(value, 10);
+  // Values may be comma-formatted (e.g. "15,356,161"); parseInt stops at the
+  // first non-digit character, so strip thousands separators first or large
+  // counts get silently truncated (e.g. "16,842,392" -> 16).
+  const digitsOnly = value.replace(/,/g, '');
+  const num = parseInt(digitsOnly, 10);
   if (!Number.isFinite(num)) return 0;
   // Fractional bump ensures "999+" sorts strictly above "999".
   return isPlus ? num + 0.5 : num;
@@ -56,7 +60,9 @@ export function parseDependentsCount(value: string | undefined): number {
 export function formatDependentsCount(value: string | undefined): string {
   if (!value) return '0';
   const isPlus = value.endsWith('+');
-  const num = parseInt(value, 10);
+  // Strip thousands separators before parsing; see parseDependentsCount.
+  const digitsOnly = value.replace(/,/g, '');
+  const num = parseInt(digitsOnly, 10);
   if (!Number.isFinite(num)) return '0';
   return isPlus ? `${num.toLocaleString()}+` : num.toLocaleString();
 }

--- a/src/frontend/tests/actionsService.spec.ts
+++ b/src/frontend/tests/actionsService.spec.ts
@@ -1,5 +1,5 @@
 import { test, expect } from '@playwright/test';
-import { ActionsService } from '../src/services/actionsService';
+import { ActionsService, parseDependentsCount, formatDependentsCount } from '../src/services/actionsService';
 
 type FetchStub = (input: RequestInfo | URL, init?: RequestInit) => Promise<Response>;
 
@@ -134,5 +134,33 @@ test.describe('actionsService README client-side cache', () => {
     } finally {
       service.destroy();
     }
+  });
+});
+
+test.describe('dependents count parsing', () => {
+  test('parseDependentsCount strips thousands separators instead of truncating', () => {
+    // Regression test: parseInt() alone stops at the first comma, so
+    // "16,842,392" would incorrectly parse as 16.
+    expect(parseDependentsCount('16,842,392')).toBe(16842392);
+    expect(parseDependentsCount('15,356,161')).toBe(15356161);
+    expect(parseDependentsCount('999')).toBe(999);
+    expect(parseDependentsCount('999+')).toBe(999.5);
+    expect(parseDependentsCount('1,234+')).toBe(1234.5);
+    expect(parseDependentsCount(undefined)).toBe(0);
+    expect(parseDependentsCount('')).toBe(0);
+    expect(parseDependentsCount('not-a-number')).toBe(0);
+  });
+
+  test('formatDependentsCount strips thousands separators instead of truncating', () => {
+    // Use toLocaleString() for the expected value so this test doesn't
+    // depend on the runtime's locale (thousands separator may be "," or ".").
+    expect(formatDependentsCount('16,842,392')).toBe((16842392).toLocaleString());
+    expect(formatDependentsCount('15,356,161')).toBe((15356161).toLocaleString());
+    expect(formatDependentsCount('999')).toBe('999');
+    expect(formatDependentsCount('999+')).toBe('999+');
+    expect(formatDependentsCount('1,234+')).toBe(`${(1234).toLocaleString()}+`);
+    expect(formatDependentsCount(undefined)).toBe('0');
+    expect(formatDependentsCount('')).toBe('0');
+    expect(formatDependentsCount('not-a-number')).toBe('0');
   });
 });


### PR DESCRIPTION
## Problem

The marketplace was showing tiny \"used by\" numbers (e.g. 16) for very popular actions like actions/checkout, which actually has 15M+ dependent repositories on GitHub.

## Root cause

The dependents count is scraped from GitHub's /network/dependents page as a comma-formatted string (e.g. \"15,356,161\") and passed through unchanged all the way to the frontend (scraper -> blob storage -> API -> Azure Table Storage -> frontend). parseDependentsCount/formatDependentsCount in actionsService.ts called parseInt(value, 10) directly on that string. parseInt stops parsing at the first non-digit character, so a count like \"16,842,392\" was silently truncated to 16.

Verified independently that:
- GitHub's dependents page tab does show the true total (not a paginated sample).
- The PowerShell scraper (dependents.ps1 in actions-marketplace-checks) correctly captures the full comma-formatted number.
- The truncation happens purely in this frontend parsing step.

## Fix

Strip commas before calling parseInt in both parseDependentsCount and formatDependentsCount.

## Tests

Added regression tests in tests/actionsService.spec.ts covering comma-formatted counts, the + suffix, and edge cases. All 7 tests pass; tsc --noEmit is clean.

## Related docs

Added .github/instructions/dependents-count.instructions.md pointing to a full investigation runbook (actions-marketplace-checks/DEPENDENTS-COUNT-DEBUGGING.md).