### PR TITLE
Annotate GitHub-owned actions with a logo badge and filter

### DIFF
--- a/src/frontend/src/App.css
+++ b/src/frontend/src/App.css
@@ -500,6 +500,9 @@ body {
   color: var(--c-text-3);
   margin-bottom: 2px;
   letter-spacing: 0.2px;
+  display: flex;
+  align-items: center;
+  gap: 6px;
 }
 
 .action-name {
@@ -560,6 +563,19 @@ body {
   font-size: 11px;
   font-weight: 700;
   border: 1.5px solid var(--c-red-border);
+}
+
+.github-owned-badge {
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+  background: var(--c-surface-2);
+  color: var(--c-text);
+  padding: 3px 10px;
+  border-radius: var(--r-pill);
+  font-size: 11px;
+  font-weight: 700;
+  border: 1.5px solid var(--c-border);
 }
 
 /* ===================================================

--- a/src/frontend/src/components/GitHubOwnedBadge.tsx
+++ b/src/frontend/src/components/GitHubOwnedBadge.tsx
@@ -1,0 +1,34 @@
+import React from 'react';
+
+interface GitHubOwnedBadgeProps {
+  className?: string;
+}
+
+/**
+ * Small pill badge with the GitHub mark (Octocat), used to flag actions
+ * owned by GitHub itself (e.g. actions/checkout, github/codeql-action).
+ */
+export const GitHubOwnedBadge: React.FC<GitHubOwnedBadgeProps> = ({ className }) => (
+  <span className={`github-owned-badge ${className || ''}`} title="Owned by GitHub">
+    <svg
+      viewBox="0 0 16 16"
+      width="12"
+      height="12"
+      aria-hidden="true"
+      fill="currentColor"
+    >
+      <path d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38
+        0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13
+        -.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66
+        .07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15
+        -.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27
+        .68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12
+        .51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48
+        0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.01 8.01 0 0 0 16 8c0-4.42-3.58-8-8-8z"
+      />
+    </svg>
+    <span>GitHub</span>
+  </span>
+);
+
+export default GitHubOwnedBadge;

--- a/src/frontend/src/pages/DetailPage.tsx
+++ b/src/frontend/src/pages/DetailPage.tsx
@@ -3,7 +3,8 @@ import { useParams, useNavigate } from 'react-router-dom';
 import DOMPurify from 'dompurify';
 import { Action } from '../types/Action';
 import { actionsService, formatDependentsCount } from '../services/actionsService';
-import { splitOwnerRepo } from '../services/utils';
+import { splitOwnerRepo, isGitHubOwnedAction } from '../services/utils';
+import { GitHubOwnedBadge } from '../components/GitHubOwnedBadge';
 
 export const DetailPage: React.FC = () => {
   const { owner, name } = useParams<{ owner: string; name: string }>();
@@ -155,6 +156,7 @@ export const DetailPage: React.FC = () => {
         <div className="detail-header">
           <h1 className="detail-title">{`${action.owner} / ${splitOwnerRepo(action).repo}`}</h1>
           <div className="detail-badges">
+            {isGitHubOwnedAction(action) && <GitHubOwnedBadge />}
             <span
               className={`action-badge ${getActionTypeBadgeClass(
                 action.actionType.actionType

--- a/src/frontend/src/pages/OverviewPage.tsx
+++ b/src/frontend/src/pages/OverviewPage.tsx
@@ -2,9 +2,10 @@ import React, { useEffect, useMemo, useRef, useState, useDeferredValue } from 'r
 import { useNavigate } from 'react-router-dom';
 import { Action, ActionStats, ActionTypeFilter } from '../types/Action';
 import { actionsService, parseDependentsCount, formatDependentsCount } from '../services/actionsService';
-import { normalizeRepoName, matchesSearchQuery, isActionVerified } from '../services/utils';
+import { normalizeRepoName, matchesSearchQuery, isActionVerified, isGitHubOwnedAction } from '../services/utils';
 import { AnimatedCounter } from '../components/AnimatedCounter';
 import { NavBar } from '../components/NavBar';
+import { GitHubOwnedBadge } from '../components/GitHubOwnedBadge';
 
 const PAGE_SIZE = 12;
 const OVERVIEW_STATE_KEY = 'overviewState:v1';
@@ -25,6 +26,7 @@ type OverviewUiState = {
   currentPage: number;
   scrollY?: number;
   openssfFilter?: 'all' | 'above5' | 'above7';
+  githubOwnedFilter?: 'all' | 'only' | 'hide';
 };
 
 function readOverviewState(): Partial<OverviewUiState> | null {
@@ -79,6 +81,10 @@ export const OverviewPage: React.FC = () => {
     const candidate = initialPersisted?.openssfFilter as string | undefined;
     return candidate === 'above5' || candidate === 'above7' ? candidate : 'all';
   });
+  const [githubOwnedFilter, setGithubOwnedFilter] = useState<'all' | 'only' | 'hide'>(() => {
+    const candidate = (initialPersisted as any)?.githubOwnedFilter as string | undefined;
+    return candidate === 'only' || candidate === 'hide' ? candidate : 'all';
+  });
   const [sortBy, setSortBy] = useState<'updated' | 'dependents'>(() => (initialPersisted?.sortBy === 'dependents' ? 'dependents' : 'updated'));
   const [currentPage, setCurrentPage] = useState(() => {
     const candidate = Number(initialPersisted?.currentPage);
@@ -97,7 +103,8 @@ export const OverviewPage: React.FC = () => {
     activityFilter,
     verifiedFilter,
     sortBy,
-    openssfFilter
+    openssfFilter,
+    githubOwnedFilter
   });
   const restoredScrollRef = useRef(false);
 
@@ -132,6 +139,7 @@ export const OverviewPage: React.FC = () => {
     setActivityFilter('hide');
     setOpenssfFilter('all');
     setSortBy('updated');
+    setGithubOwnedFilter('all');
     setCurrentPage(1);
     try {
       sessionStorage.removeItem(OVERVIEW_STATE_KEY);
@@ -212,9 +220,10 @@ export const OverviewPage: React.FC = () => {
       activityFilter,
       sortBy,
       openssfFilter,
+      githubOwnedFilter,
       currentPage
     });
-  }, [searchQuery, typeFilter, showVerifiedOnly, verifiedFilter, archivedFilter, activityFilter, sortBy, openssfFilter, currentPage]);
+  }, [searchQuery, typeFilter, showVerifiedOnly, verifiedFilter, archivedFilter, activityFilter, sortBy, openssfFilter, githubOwnedFilter, currentPage]);
 
   // Memoize filter+sort to avoid recomputing on every render.
   // Uses deferredSearchQuery so typing does not block the UI.
@@ -268,6 +277,12 @@ export const OverviewPage: React.FC = () => {
       });
     }
 
+    if (githubOwnedFilter === 'only') {
+      filtered = filtered.filter(action => isGitHubOwnedAction(action));
+    } else if (githubOwnedFilter === 'hide') {
+      filtered = filtered.filter(action => !isGitHubOwnedAction(action));
+    }
+
     // Apply sorting
     return [...filtered].sort((a, b) => {
       if (sortBy === 'dependents') {
@@ -281,7 +296,7 @@ export const OverviewPage: React.FC = () => {
         return bDate - aDate; // Descending (most recent first)
       }
     });
-  }, [actions, deferredSearchQuery, typeFilter, showVerifiedOnly, archivedFilter, activityFilter, verifiedFilter, sortBy, openssfFilter]);
+  }, [actions, deferredSearchQuery, typeFilter, showVerifiedOnly, archivedFilter, activityFilter, verifiedFilter, sortBy, openssfFilter, githubOwnedFilter]);
 
   // Reset page to 1 when filter criteria change; clamp when only the actions list updates.
   useEffect(() => {
@@ -294,9 +309,10 @@ export const OverviewPage: React.FC = () => {
       prev.archivedFilter !== archivedFilter ||
       prev.activityFilter !== activityFilter ||
       prev.sortBy !== sortBy ||
-      prev.openssfFilter !== openssfFilter;
+      prev.openssfFilter !== openssfFilter ||
+      prev.githubOwnedFilter !== githubOwnedFilter;
 
-    prevFiltersRef.current = { searchQuery: deferredSearchQuery, typeFilter, showVerifiedOnly, archivedFilter, activityFilter, verifiedFilter, sortBy, openssfFilter };
+    prevFiltersRef.current = { searchQuery: deferredSearchQuery, typeFilter, showVerifiedOnly, archivedFilter, activityFilter, verifiedFilter, sortBy, openssfFilter, githubOwnedFilter };
 
     const nextTotalPages = Math.max(1, Math.ceil(filteredActions.length / PAGE_SIZE));
     if (filtersChanged) {
@@ -304,7 +320,7 @@ export const OverviewPage: React.FC = () => {
     } else {
       setCurrentPage(p => Math.min(Math.max(p, 1), nextTotalPages));
     }
-  }, [filteredActions, deferredSearchQuery, typeFilter, showVerifiedOnly, archivedFilter, activityFilter, verifiedFilter, sortBy, openssfFilter]);
+  }, [filteredActions, deferredSearchQuery, typeFilter, showVerifiedOnly, archivedFilter, activityFilter, verifiedFilter, sortBy, openssfFilter, githubOwnedFilter]);
 
   useEffect(() => {
     if (restoredScrollRef.current) {
@@ -554,6 +570,15 @@ export const OverviewPage: React.FC = () => {
           </div>
 
           <div className="filter-group">
+            <label>GitHub-owned:</label>
+            <select data-testid="filter-github-owned" value={githubOwnedFilter} onChange={e => setGithubOwnedFilter(e.target.value as any)}>
+              <option value="all">All</option>
+              <option value="only">Only GitHub-owned</option>
+              <option value="hide">Hide GitHub-owned</option>
+            </select>
+          </div>
+
+          <div className="filter-group">
             <label>Sort by:</label>
             <button data-testid="sort-updated"
               className={sortBy === 'updated' ? 'active' : ''}
@@ -598,7 +623,10 @@ export const OverviewPage: React.FC = () => {
               >
                 <div className="action-header">
                   <div className="action-title">
-                      <div className="action-owner">{action.owner}</div>
+                      <div className="action-owner">
+                        {action.owner}
+                        {isGitHubOwnedAction(action) && <GitHubOwnedBadge />}
+                      </div>
                       <div className="action-name">{normalizeRepoName(action.owner, action.name)}</div>
                   </div>
                   <span

--- a/src/frontend/src/services/utils.ts
+++ b/src/frontend/src/services/utils.ts
@@ -46,3 +46,11 @@ export function isActionVerified(action: Partial<Action> | { verified?: unknown 
   }
   return false;
 }
+
+// GitHub-owned actions live under these orgs (e.g. actions/checkout, github/codeql-action).
+const GITHUB_OWNED_ORGS = new Set(['actions', 'github']);
+
+export function isGitHubOwnedAction(action: Partial<Action> | { owner?: string }) {
+  const owner = String((action && (action as any).owner) || '').toLowerCase().trim();
+  return GITHUB_OWNED_ORGS.has(owner);
+}

--- a/src/frontend/tests/isGitHubOwnedAction.spec.ts
+++ b/src/frontend/tests/isGitHubOwnedAction.spec.ts
@@ -1,0 +1,27 @@
+import { test, expect } from '@playwright/test';
+import { isGitHubOwnedAction } from '../src/services/utils';
+
+test.describe('isGitHubOwnedAction helper', () => {
+  test('actions org is GitHub-owned', () => {
+    expect(isGitHubOwnedAction({ owner: 'actions' })).toBe(true);
+  });
+
+  test('github org is GitHub-owned', () => {
+    expect(isGitHubOwnedAction({ owner: 'github' })).toBe(true);
+  });
+
+  test('is case-insensitive', () => {
+    expect(isGitHubOwnedAction({ owner: 'Actions' })).toBe(true);
+    expect(isGitHubOwnedAction({ owner: 'GitHub' })).toBe(true);
+  });
+
+  test('other owners are not GitHub-owned', () => {
+    expect(isGitHubOwnedAction({ owner: 'docker' })).toBe(false);
+    expect(isGitHubOwnedAction({ owner: 'azure' })).toBe(false);
+    expect(isGitHubOwnedAction({ owner: 'some-random-user' })).toBe(false);
+  });
+
+  test('missing owner', () => {
+    expect(isGitHubOwnedAction({})).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary
Clearly flags actions owned by GitHub (owner `actions` or `github`, e.g. `actions/checkout`, `github/codeql-action`) with a GitHub-mark badge, on both the overview card and the detail page, plus a dedicated filter.

## Changes
- `services/utils.ts`: new `isGitHubOwnedAction()` helper (case-insensitive owner check against `actions`/`github`).
- `components/GitHubOwnedBadge.tsx`: new reusable pill badge with an inline GitHub/Octocat SVG mark.
- `OverviewPage.tsx`: badge shown next to the owner name on each action card; new "GitHub-owned" filter dropdown (`All` / `Only GitHub-owned` / `Hide GitHub-owned`), persisted like the other filters.
- `DetailPage.tsx`: badge shown alongside the existing Verified/Archived badges.
- `App.css`: styles for `.github-owned-badge`.
- New unit tests for `isGitHubOwnedAction`.

## Notes
- "GitHub-owned" is defined as the `actions` and `github` GitHub orgs — the standard convention for official GitHub Actions (e.g. actions/checkout, actions/setup-node, github/codeql-action). Let me know if you'd like other orgs (e.g. `azure`, `docker`) included.
- Verified locally: `npm run build` succeeds and the new/related Playwright unit tests (`isGitHubOwnedAction.spec.ts`, `isActionVerified.spec.ts`, `utils.spec.ts`) all pass (14/14).

Co-authored-by: Copilot App <223556219+Copilot@users.noreply.github.com>