### PR TITLE
fix: restore push trigger on deploy-app.yml for src changes on main

### DIFF
--- a/.github/workflows/deploy-app.yml
+++ b/.github/workflows/deploy-app.yml
@@ -18,6 +18,12 @@ on:
         required: true
         default: true
         type: boolean
+  push:
+    branches:
+      - main
+    paths:
+      - 'src/frontend/**'
+      - 'src/backend/**'
 
 
 env:


### PR DESCRIPTION
## Why

`Deploy App (Frontend + Backend)` was made `workflow_dispatch`-only in PR #83, so merges to `main` no longer trigger a real deployment. Today 3 PRs merged to `main` and none of them deployed — the only workflows that auto-run on push (`Staged Deploy`, `swa-test`) are non-functional demos gated on a dead `AZURE_CREDENTIALS` secret that's never been set (the repo uses OIDC via `AZURE_CLIENT_ID`/`AZURE_TENANT_ID`/`AZURE_SUBSCRIPTION_ID` instead).

## What changed

Restored a `push` trigger on `deploy-app.yml`, scoped to:
- `branches: [main]` only (dependabot branches never push directly to `main`, so they're naturally excluded — no separate exclusion needed)
- `paths: ['src/frontend/**', 'src/backend/**']` so unrelated pushes to `main` (docs, workflow tweaks, etc.) don't trigger a redeploy

The workflow already had `changes`/`DO_FRONTEND`/`DO_BACKEND` logic built to support push-triggered, path-based deploys (added generically for `workflow_dispatch` vs. other events) — it was just missing the trigger itself.

## Verification

- `actionlint` passes clean on the changed file.
- Manually triggered `Deploy App (Frontend + Backend)` via `workflow_dispatch` for the current `main` (run [29911943569](https://github.com/devops-actions/alternative-github-actions-marketplace/actions/runs/29911943569)) to deploy today's 3 merged PRs — Deploy Backend and Deploy Frontend both succeeded.

Co-authored-by: Copilot App <223556219+Copilot@users.noreply.github.com>