### PR TITLE
Fix dark mode on Data Status and About pages

### DIFF
--- a/src/frontend/src/App.css
+++ b/src/frontend/src/App.css
@@ -1091,29 +1091,29 @@ body {
 }
 
 .status-card {
-  background: white;
-  border: 1px solid #d1d5da;
+  background: var(--c-surface);
+  border: 1px solid var(--c-border-strong);
   border-radius: 8px;
   padding: 24px;
   margin-bottom: 20px;
-  box-shadow: 0 1px 3px rgba(0,0,0,0.07);
+  box-shadow: var(--shadow-sm);
 }
 
 .status-card-title {
   font-size: 18px;
   font-weight: 600;
   margin-bottom: 12px;
-  color: #24292e;
+  color: var(--c-text);
 }
 
 .status-explanation {
   font-size: 14px;
-  color: #586069;
+  color: var(--c-text-2);
   line-height: 1.6;
 }
 
 .status-explanation a {
-  color: #0366d6;
+  color: var(--c-primary);
   text-decoration: none;
 }
 
@@ -1130,28 +1130,28 @@ body {
 
 .status-summary-card {
   flex: 1 1 200px;
-  background: white;
-  border: 1px solid #d1d5da;
+  background: var(--c-surface);
+  border: 1px solid var(--c-border-strong);
   border-radius: 8px;
   padding: 20px;
-  box-shadow: 0 1px 3px rgba(0,0,0,0.07);
+  box-shadow: var(--shadow-sm);
 }
 
 .status-summary-label {
   font-size: 13px;
-  color: #586069;
+  color: var(--c-text-2);
   margin-bottom: 6px;
 }
 
 .status-summary-value {
   font-size: 22px;
   font-weight: 600;
-  color: #0366d6;
+  color: var(--c-primary);
 }
 
 .status-summary-sub {
   font-size: 12px;
-  color: #999;
+  color: var(--c-text-3);
   margin-top: 4px;
 }
 
@@ -1169,17 +1169,17 @@ body {
 .age-bucket-label {
   font-size: 14px;
   font-weight: 600;
-  color: #24292e;
+  color: var(--c-text);
 }
 
 .age-bucket-count {
   font-size: 13px;
-  color: #586069;
+  color: var(--c-text-2);
 }
 
 .age-bucket-bar-bg {
   height: 12px;
-  background: #f1f3f5;
+  background: var(--c-surface-2);
   border-radius: 6px;
   overflow: hidden;
   margin-bottom: 4px;
@@ -1194,12 +1194,12 @@ body {
 
 .age-bucket-desc {
   font-size: 12px;
-  color: #999;
+  color: var(--c-text-3);
 }
 
 .status-generated {
   font-size: 12px;
-  color: #999;
+  color: var(--c-text-3);
   text-align: right;
   margin-bottom: 20px;
 }

--- a/src/frontend/src/pages/AboutPage.tsx
+++ b/src/frontend/src/pages/AboutPage.tsx
@@ -20,7 +20,7 @@ export const AboutPage: React.FC = () => {
           style={{
             background: 'none',
             border: 'none',
-            color: '#0366d6',
+            color: 'var(--c-primary)',
             cursor: 'pointer',
             fontSize: 14,
             padding: '4px 0'

--- a/src/frontend/src/pages/StatusPage.tsx
+++ b/src/frontend/src/pages/StatusPage.tsx
@@ -103,7 +103,7 @@ export const StatusPage: React.FC = () => {
           style={{
             background: 'none',
             border: 'none',
-            color: '#0366d6',
+            color: 'var(--c-primary)',
             cursor: 'pointer',
             fontSize: 14,
             padding: '4px 0'


### PR DESCRIPTION
The Data Status and About pages stayed in light mode even when the rest of the site follows the OS dark/light preference, because their card and text styles used hardcoded hex colors instead of the shared theme variables.

Replaced the hardcoded colors in `.status-card`, `.status-summary-card`, `.age-bucket-*`, and `.status-generated` rules in `App.css` with the existing CSS custom properties (`--c-surface`, `--c-text`, `--c-text-2`, `--c-text-3`, `--c-primary`, `--c-border-strong`, `--c-surface-2`), which already have dark-mode overrides defined via `@media (prefers-color-scheme: dark)`. Also updated the inline "Back to marketplace" link color in `StatusPage.tsx` and `AboutPage.tsx` to use `var(--c-primary)` instead of a fixed blue.

No behavior changes in light mode; verified with `npm run build`.