### PR TITLE
Fix broken README images from repo-relative image paths

### DIFF
--- a/src/backend/ActionsReadme/index.js
+++ b/src/backend/ActionsReadme/index.js
@@ -6,6 +6,7 @@ const { ActionRecord } = require('../lib/actionRecord');
 const { extractRepoName } = require('../lib/actionNameDecoder');
 const { cacheControlHeaders } = require('../lib/cacheHeaders');
 const { normalizePartitionKey, normalizeRowKey } = require('../lib/keyUtils');
+const { rewriteRelativeAssetUrls } = require('../lib/readmeAssets');
 
 const CACHE_MAX_AGE_SECONDS = 1800; // 30 minutes
 
@@ -26,15 +27,36 @@ function sanitizeVersion(rawVersion) {
   return sanitized || 'main';
 }
 
+// GitHub allows a repo's displayed README to live in the root, docs/, or
+// .github/ folder. The HTML-rendered readme response doesn't say which, so
+// we fetch the JSON metadata in parallel just to learn the README's path,
+// which is needed to resolve its relative image links correctly. A failure
+// here isn't fatal - we fall back to assuming a root-level README.
+async function fetchReadmePath(url, headers) {
+  try {
+    const response = await fetch(url, { headers: { ...headers, Accept: 'application/vnd.github+json' } });
+    if (!response.ok) {
+      return null;
+    }
+    const data = await response.json();
+    return data && typeof data.path === 'string' ? data.path : null;
+  } catch (error) {
+    return null;
+  }
+}
+
 async function fetchReadmeFromGitHub(owner, name, version) {
   const ref = version || 'main';
   const repoName = extractRepoName(owner, name);
   const url = `https://api.github.com/repos/${owner}/${repoName}/readme?ref=${ref}`;
-  
+
   const headers = await getPublicReadHeaders();
 
-  const response = await fetch(url, { headers });
-  
+  const [response, readmePath] = await Promise.all([
+    fetch(url, { headers }),
+    fetchReadmePath(url, headers)
+  ]);
+
   if (!response.ok) {
     if (response.status === 404) {
       return null;
@@ -46,7 +68,7 @@ async function fetchReadmeFromGitHub(owner, name, version) {
   if (!html) {
     throw new Error(`GitHub API returned empty body for ${owner}/${repoName}@${ref}`);
   }
-  return html;
+  return rewriteRelativeAssetUrls(html, owner, repoName, ref, readmePath);
 }
 
 async function getRepoUpdatedAt(owner, name) {

--- a/src/backend/lib/readmeAssets.js
+++ b/src/backend/lib/readmeAssets.js
@@ -1,0 +1,108 @@
+const { posix } = require('path');
+
+const ABSOLUTE_URL_REGEX = /^([a-z][a-z0-9+.-]*:|\/\/)/i;
+
+/**
+ * Returns the repo-relative directory a README lives in, with a trailing
+ * slash, or '' for a repo-root README. GitHub allows a repo's displayed
+ * README to live in the root, docs/, or .github/, and relative image paths
+ * inside it are resolved against that directory, not the repo root.
+ * @param {string|null|undefined} readmePath - path of the README file as
+ *   returned by the GitHub contents API (e.g. "docs/README.md")
+ * @returns {string} directory prefix, e.g. "docs/" or ""
+ */
+function getReadmeDir(readmePath) {
+  if (!readmePath) {
+    return '';
+  }
+  const dir = posix.dirname(readmePath);
+  return !dir || dir === '.' ? '' : `${dir}/`;
+}
+
+function isAbsoluteUrl(url) {
+  return ABSOLUTE_URL_REGEX.test(url.trim());
+}
+
+function resolveRelativeUrl(relativeUrl, baseUrl) {
+  try {
+    return new URL(relativeUrl, baseUrl).toString();
+  } catch (error) {
+    return relativeUrl;
+  }
+}
+
+function rewriteSrc(attrs, baseUrl) {
+  return attrs.replace(/(\ssrc\s*=\s*)("([^"]*)"|'([^']*)')/gi, (match, prefix, quoted, dq, sq) => {
+    const value = dq !== undefined ? dq : sq;
+    const quote = quoted[0];
+    if (!value || isAbsoluteUrl(value) || value.startsWith('data:')) {
+      return match;
+    }
+    return `${prefix}${quote}${resolveRelativeUrl(value, baseUrl)}${quote}`;
+  });
+}
+
+function rewriteSrcset(attrs, baseUrl) {
+  return attrs.replace(/(\ssrcset\s*=\s*)("([^"]*)"|'([^']*)')/gi, (match, prefix, quoted, dq, sq) => {
+    const value = dq !== undefined ? dq : sq;
+    const quote = quoted[0];
+    if (!value) {
+      return match;
+    }
+
+    const rewritten = value
+      .split(',')
+      .map((candidate) => {
+        const trimmed = candidate.trim();
+        if (!trimmed) {
+          return trimmed;
+        }
+        const spaceIndex = trimmed.indexOf(' ');
+        const url = spaceIndex === -1 ? trimmed : trimmed.slice(0, spaceIndex);
+        const descriptor = spaceIndex === -1 ? '' : trimmed.slice(spaceIndex);
+        if (isAbsoluteUrl(url) || url.startsWith('data:')) {
+          return trimmed;
+        }
+        return `${resolveRelativeUrl(url, baseUrl)}${descriptor}`;
+      })
+      .join(', ');
+
+    return `${prefix}${quote}${rewritten}${quote}`;
+  });
+}
+
+/**
+ * Rewrites repo-relative image sources in GitHub-rendered README HTML to
+ * absolute raw.githubusercontent.com URLs.
+ *
+ * GitHub's HTML render of a README keeps same-repo image paths relative
+ * (e.g. src="images/foo.png"), which only resolve correctly on github.com
+ * itself. Embedded on another origin, the browser resolves them against
+ * that origin instead, so the images 404. Only <img>/<source> src and
+ * srcset are rewritten; already-absolute URLs (including camo-proxied
+ * badges) are left untouched.
+ * @param {string} html - README HTML as returned by the GitHub API
+ * @param {string} owner - Repository owner
+ * @param {string} repoName - Repository name
+ * @param {string} ref - Branch, tag, or commit the README was fetched at
+ * @param {string} [readmePath] - path of the README file within the repo
+ *   (e.g. "docs/README.md"), used to resolve relative asset paths against
+ *   the README's actual directory instead of assuming the repo root
+ * @returns {string} HTML with relative asset URLs rewritten to absolute URLs
+ */
+function rewriteRelativeAssetUrls(html, owner, repoName, ref, readmePath) {
+  if (!html) {
+    return html;
+  }
+
+  const baseUrl = `https://raw.githubusercontent.com/${owner}/${repoName}/${ref}/${getReadmeDir(readmePath)}`;
+
+  return html.replace(/<(img|source)\b([^>]*)>/gi, (match, tag, attrs) => {
+    const rewrittenAttrs = rewriteSrcset(rewriteSrc(attrs, baseUrl), baseUrl);
+    return `<${tag}${rewrittenAttrs}>`;
+  });
+}
+
+module.exports = {
+  rewriteRelativeAssetUrls
+};

--- a/src/backend/tests/actionsReadme.test.js
+++ b/src/backend/tests/actionsReadme.test.js
@@ -322,4 +322,61 @@ describe('actionsReadme function', () => {
     expect(context.res.body.error).toContain('invalid characters');
     expect(global.fetch).not.toHaveBeenCalled();
   });
+
+  it('rewrites relative image sources using the README path from GitHub metadata', async () => {
+    mockGetActionEntity.mockResolvedValue(null);
+    mockGetCachedReadme.mockResolvedValue(null);
+    mockCacheReadme.mockResolvedValue(undefined);
+
+    global.fetch.mockImplementation((url, options) => {
+      if (options.headers.Accept === 'application/vnd.github+json') {
+        return Promise.resolve({
+          ok: true,
+          json: jest.fn().mockResolvedValue({ path: 'docs/README.md' })
+        });
+      }
+      return Promise.resolve({
+        ok: true,
+        status: 200,
+        text: jest.fn().mockResolvedValue('<img src="images/foo.png">')
+      });
+    });
+
+    const context = createContext('step-security', 'harden-runner');
+    const req = { method: 'GET', headers: {}, query: {} };
+
+    await actionsReadme(context, req);
+
+    expect(context.res.status).toBe(200);
+    expect(context.res.body).toContain(
+      'src="https://raw.githubusercontent.com/step-security/harden-runner/main/docs/images/foo.png"'
+    );
+  });
+
+  it('falls back to root-relative rewriting when the metadata lookup fails', async () => {
+    mockGetActionEntity.mockResolvedValue(null);
+    mockGetCachedReadme.mockResolvedValue(null);
+    mockCacheReadme.mockResolvedValue(undefined);
+
+    global.fetch.mockImplementation((url, options) => {
+      if (options.headers.Accept === 'application/vnd.github+json') {
+        return Promise.reject(new Error('network error'));
+      }
+      return Promise.resolve({
+        ok: true,
+        status: 200,
+        text: jest.fn().mockResolvedValue('<img src="images/foo.png">')
+      });
+    });
+
+    const context = createContext('step-security', 'harden-runner');
+    const req = { method: 'GET', headers: {}, query: {} };
+
+    await actionsReadme(context, req);
+
+    expect(context.res.status).toBe(200);
+    expect(context.res.body).toContain(
+      'src="https://raw.githubusercontent.com/step-security/harden-runner/main/images/foo.png"'
+    );
+  });
 });

--- a/src/backend/tests/readmeAssets.test.js
+++ b/src/backend/tests/readmeAssets.test.js
@@ -1,0 +1,99 @@
+const { rewriteRelativeAssetUrls } = require('../lib/readmeAssets');
+
+describe('rewriteRelativeAssetUrls', () => {
+  const owner = 'step-security';
+  const repoName = 'harden-runner';
+  const ref = 'main';
+
+  it('rewrites a relative img src to an absolute raw.githubusercontent.com URL', () => {
+    const html = '<img alt="Dark Banner" src="images/harden-runner-new.png" width="400">';
+    const result = rewriteRelativeAssetUrls(html, owner, repoName, ref);
+
+    expect(result).toContain(
+      'src="https://raw.githubusercontent.com/step-security/harden-runner/main/images/harden-runner-new.png"'
+    );
+  });
+
+  it('leaves already-absolute img src untouched', () => {
+    const html = '<img src="https://camo.githubusercontent.com/abc" alt="badge">';
+    const result = rewriteRelativeAssetUrls(html, owner, repoName, ref);
+
+    expect(result).toBe(html);
+  });
+
+  it('leaves protocol-relative and data URIs untouched', () => {
+    const html = '<img src="//example.com/foo.png"><img src="data:image/png;base64,AAA">';
+    const result = rewriteRelativeAssetUrls(html, owner, repoName, ref);
+
+    expect(result).toBe(html);
+  });
+
+  it('rewrites relative srcset candidates while preserving descriptors', () => {
+    const html = '<source srcset="images/a.png 1x, images/b.png 2x, https://example.com/c.png 3x">';
+    const result = rewriteRelativeAssetUrls(html, owner, repoName, ref);
+
+    expect(result).toBe(
+      '<source srcset="https://raw.githubusercontent.com/step-security/harden-runner/main/images/a.png 1x, ' +
+      'https://raw.githubusercontent.com/step-security/harden-runner/main/images/b.png 2x, https://example.com/c.png 3x">'
+    );
+  });
+
+  it('resolves relative paths using the given ref', () => {
+    const html = '<img src="images/case-study.png">';
+    const result = rewriteRelativeAssetUrls(html, owner, repoName, 'v2.1.0');
+
+    expect(result).toContain(
+      'src="https://raw.githubusercontent.com/step-security/harden-runner/v2.1.0/images/case-study.png"'
+    );
+  });
+
+  it('does not touch non-img/source tags such as anchors', () => {
+    const html = '<a href="docs/how-it-works.md">How it works</a>';
+    const result = rewriteRelativeAssetUrls(html, owner, repoName, ref);
+
+    expect(result).toBe(html);
+  });
+
+  it('returns falsy input unchanged', () => {
+    expect(rewriteRelativeAssetUrls('', owner, repoName, ref)).toBe('');
+    expect(rewriteRelativeAssetUrls(null, owner, repoName, ref)).toBe(null);
+  });
+
+  describe('when the README lives in a subdirectory', () => {
+    it('resolves relative paths against the README directory, not the repo root', () => {
+      const html = '<img src="images/foo.png">';
+      const result = rewriteRelativeAssetUrls(html, owner, repoName, ref, 'docs/README.md');
+
+      expect(result).toContain(
+        'src="https://raw.githubusercontent.com/step-security/harden-runner/main/docs/images/foo.png"'
+      );
+    });
+
+    it('handles a nested .github README', () => {
+      const html = '<img src="assets/banner.png">';
+      const result = rewriteRelativeAssetUrls(html, owner, repoName, ref, '.github/README.md');
+
+      expect(result).toContain(
+        'src="https://raw.githubusercontent.com/step-security/harden-runner/main/.github/assets/banner.png"'
+      );
+    });
+
+    it('falls back to repo root when readmePath is not provided', () => {
+      const html = '<img src="images/foo.png">';
+      const result = rewriteRelativeAssetUrls(html, owner, repoName, ref);
+
+      expect(result).toContain(
+        'src="https://raw.githubusercontent.com/step-security/harden-runner/main/images/foo.png"'
+      );
+    });
+
+    it('treats a root-level readmePath the same as no path', () => {
+      const html = '<img src="images/foo.png">';
+      const result = rewriteRelativeAssetUrls(html, owner, repoName, ref, 'README.md');
+
+      expect(result).toContain(
+        'src="https://raw.githubusercontent.com/step-security/harden-runner/main/images/foo.png"'
+      );
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- GitHub's HTML-rendered README keeps same-repo image sources relative (e.g. `src="images/foo.png"`), which only resolves on github.com itself; embedded on our own origin, the browser resolves it against our domain instead, so screenshots 404 (e.g. `step-security/harden-runner`'s images at https://alternative-github-actions-marketplace.devopsjournal.io/action/step-security/step-security_harden-runner).
- Added `src/backend/lib/readmeAssets.js`, which rewrites `<img>`/`<source>` `src`/`srcset` values that aren't already absolute into `https://raw.githubusercontent.com/{owner}/{repo}/{ref}/...` URLs, applied before the README HTML is cached.
- Resolves relative paths against the README's actual directory (root, `docs/`, or `.github/`) by fetching the JSON metadata (`path`) in parallel with the HTML fetch; falls back to repo-root resolution if that lookup fails, so the fix degrades safely rather than breaking image loading further.
- Already-absolute URLs (camo-proxied badges, avatars, shields.io) are left untouched.

## Test plan
- [x] `npx jest tests/readmeAssets.test.js tests/actionsReadme.test.js` — 33/33 passing, including root-level, subdirectory, and metadata-lookup-failure cases
- [x] Verified live against the real `step-security/harden-runner` README via the GitHub API — all 4 previously-relative images now resolve to loadable `raw.githubusercontent.com` URLs
- [ ] Manual check on the deployed site once merged, to confirm the harden-runner action page renders its screenshots

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>