### PR TITLE
Fix clipped stat labels in the marketplace stats bar

### DIFF
--- a/src/frontend/src/App.css
+++ b/src/frontend/src/App.css
@@ -186,37 +186,33 @@ body {
    =================================================== */
 .stats-bar {
   display: flex;
+  flex-wrap: wrap;
   gap: 2px;
   background: var(--c-border);
   border: 1.5px solid var(--c-border);
   border-radius: var(--r-md);
   margin-bottom: 20px;
   overflow: hidden;
-  overflow-x: auto;
   box-shadow: var(--shadow-sm);
-  scrollbar-width: none;
-}
-
-.stats-bar::-webkit-scrollbar {
-  display: none;
 }
 
 .stat-item {
   display: flex;
   flex-direction: column;
-  flex: 1;
+  justify-content: space-between;
+  /* grow to fill the row, but wrap to a new row instead of squeezing
+     the label until it is clipped by the next card */
+  flex: 1 1 130px;
+  min-width: 0;
 }
 
 .stat-button {
   border: 0;
   background: var(--c-surface);
-  padding: 16px 20px;
+  padding: 16px 16px;
   text-align: left;
   cursor: pointer;
   transition: background var(--t);
-  min-width: 110px;
-  white-space: nowrap;
-  width: 100%;
 }
 
 .stat-button:hover {
@@ -1025,9 +1021,12 @@ body {
    RESPONSIVE
    =================================================== */
 @media (max-width: 768px) {
+  .stat-item {
+    flex-basis: 110px;
+  }
+
   .stat-button {
-    padding: 14px 14px;
-    min-width: 90px;
+    padding: 14px 12px;
   }
 
   .stat-value {

--- a/src/frontend/src/pages/OverviewPage.tsx
+++ b/src/frontend/src/pages/OverviewPage.tsx
@@ -422,7 +422,7 @@ export const OverviewPage: React.FC = () => {
           onClick={() => setTypeFilterFromStats('All')}
           aria-label="Show all actions"
         >
-          <span className="stat-label">Total Actions</span>
+          <span className="stat-label">Total</span>
           <span className="stat-value"><AnimatedCounter value={stats.total} /></span>
         </button>
 
@@ -432,7 +432,7 @@ export const OverviewPage: React.FC = () => {
           onClick={() => setTypeFilterFromStats('Verified')}
           aria-label="Show verified actions"
         >
-          <span className="stat-label">Verified Actions</span>
+          <span className="stat-label">Verified</span>
           <span className="stat-value"><AnimatedCounter value={stats.verified} /></span>
         </button>
 
@@ -444,7 +444,7 @@ export const OverviewPage: React.FC = () => {
             onClick={() => setTypeFilterFromStats(type)}
             aria-label={`Filter by ${type} actions`}
           >
-            <span className="stat-label">{type} Actions</span>
+            <span className="stat-label">{type}</span>
             <span className="stat-value"><AnimatedCounter value={count} /></span>
           </button>
         ))}
@@ -455,7 +455,7 @@ export const OverviewPage: React.FC = () => {
           onClick={() => setTypeFilterFromStats('Archived')}
           aria-label="Include archived actions"
         >
-          <span className="stat-label">Archived Actions</span>
+          <span className="stat-label">Archived</span>
           <span className="stat-value"><AnimatedCounter value={stats.archived} /></span>
         </button>
 
@@ -465,7 +465,7 @@ export const OverviewPage: React.FC = () => {
           onClick={() => setOpenssfFilter('above5')}
           aria-label="Show actions with OpenSSF score"
         >
-          <span className="stat-label">OpenSSF Actions</span>
+          <span className="stat-label">OpenSSF</span>
           <span className="stat-value"><AnimatedCounter value={stats.withOssf} /></span>
         </button>
       </div>


### PR DESCRIPTION
## Problem

On the Marketplace overview the stat card titles are cut off — "COMPOSITE ACTION", "NO FILE FOUND ACT", "OPENSSF ACTION" etc.

The stats bar is a flex row of ten equal-width cards (`flex: 1`) with `white-space: nowrap` on the button. The cards shrink to ~134px, the label keeps its full nowrap width, overflows the card, and the next card's opaque background paints over it. Widening the padding alone would only move where the text gets covered.

## Fix

- `.stats-bar`: `flex-wrap: wrap`, and dropped the horizontal scroll (`overflow-x: auto` behind a hidden scrollbar) now that the bar wraps.
- `.stat-item`: `flex: 1 1 130px` + `min-width: 0` — cards grow to fill a row but wrap to a new row instead of shrinking below their label. `justify-content: space-between` keeps the numbers bottom-aligned when one card's label wraps to two lines and its neighbour's doesn't.
- `.stat-button`: removed `white-space: nowrap`, `min-width` and `width: 100%` (the flex basis sizes the card now).
- Dropped the redundant "Actions" suffix from every label — the whole bar is about actions, so "Total", "Verified", "Docker", "OpenSSF", … .
- Responsive block updated to match (`flex-basis: 110px`, smaller padding).

## Verification

Rendered the real stylesheet with the ten live labels and measured every label's `scrollWidth` vs `clientWidth`:

| viewport | layout | clipped labels |
|---|---|---|
| 1445px | 10 across, 1 row | none |
| 1200 / 1000 / 820px | 5 across, 2 rows | none |
| 640px | 3 across, 3 rows | none |
| 420 / 360px | 2 across, 5 rows | none |

Only "Error downloading" wraps to two lines at desktop width; nothing is clipped at any width.

Button `aria-label`s are unchanged, so the e2e stats panel tests (which select on aria-label) still match.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
