### PR TITLE
fix: update js-yaml to 3.15.0 to resolve security vulnerabilities

### DIFF
--- a/src/backend/package-lock.json
+++ b/src/backend/package-lock.json
@@ -6507,9 +6507,9 @@
       "license": "MIT"
     },
     "node_modules/js-yaml": {
-      "version": "3.14.2",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.2.tgz",
-      "integrity": "sha512-PMSmkqxr106Xa156c2M265Z+FTrPl+oxd/rgOQy2tijQeK5TxQ43psO1ZCwhVOSdnn+RzkzlRz/eY4BgJBYVpg==",
+      "version": "3.15.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.15.0.tgz",
+      "integrity": "sha512-ttBQIIQPDeLjpPOohtUdXuXUVoA2uIB6fEH9HyJ7234s5mBJ5wTx20njxplLZQgLaOfpmPQA7X2t5AX6tIPbog==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/src/backend/package.json
+++ b/src/backend/package.json
@@ -61,7 +61,8 @@
   },
   "overrides": {
     "@babel/core": ">=7.29.6",
-    "qs": ">=6.15.2",
-    "brace-expansion": "^5.0.7"
+    "brace-expansion": "^5.0.7",
+    "js-yaml": "^3.15.0",
+    "qs": ">=6.15.2"
   }
 }

--- a/src/mcp-server/package-lock.json
+++ b/src/mcp-server/package-lock.json
@@ -5026,9 +5026,9 @@
       "license": "MIT"
     },
     "node_modules/js-yaml": {
-      "version": "3.14.2",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.2.tgz",
-      "integrity": "sha512-PMSmkqxr106Xa156c2M265Z+FTrPl+oxd/rgOQy2tijQeK5TxQ43psO1ZCwhVOSdnn+RzkzlRz/eY4BgJBYVpg==",
+      "version": "3.15.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.15.0.tgz",
+      "integrity": "sha512-ttBQIIQPDeLjpPOohtUdXuXUVoA2uIB6fEH9HyJ7234s5mBJ5wTx20njxplLZQgLaOfpmPQA7X2t5AX6tIPbog==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/src/mcp-server/package.json
+++ b/src/mcp-server/package.json
@@ -15,8 +15,9 @@
   "overrides": {
     "@babel/core": ">=7.29.6",
     "@hono/node-server": "2.0.12",
-    "qs": ">=6.15.2",
-    "brace-expansion": "^5.0.7"
+    "brace-expansion": "^5.0.7",
+    "js-yaml": "^3.15.0",
+    "qs": ">=6.15.2"
   },
   "dependencies": {
     "@hono/node-server": "2.0.12",


### PR DESCRIPTION
## Description
Resolves Dependabot security alerts #85, #80, #74, #73 by updating \js-yaml\ to version 3.15.0.

## Issue Details
The \js-yaml\ package has a quadratic-complexity vulnerability (CPU DoS) via merge-key/alias handling in versions < 3.15.0. This dependency was flagged as vulnerable in both \src/backend/package-lock.json\ and \src/mcp-server/package-lock.json\.

## Changes
- Added \overrides\ field to \src/backend/package.json\ to enforce \js-yaml@^3.15.0\
- Added \overrides\ field to \src/mcp-server/package.json\ to enforce \js-yaml@^3.15.0\
- Ran \
pm install\ in both directories to apply the override

The vulnerable dependency was transitive:
\jest → @jest/core → @jest/transform → babel-plugin-istanbul → @istanbuljs/load-nyc-config → js-yaml\

## Verification
✅ Backend tests: 20 test suites passed, 255 tests passed
✅ MCP Server tests: 10 test suites passed, 122 tests passed
✅ js-yaml verified at 3.15.0 in both directories via \
pm ls js-yaml\

## Fixes
- Closes #85
- Closes #80
- Closes #74
- Closes #73