### PR TITLE
fix: /api/actions/list returns 500 for limit > 1000

### DIFF
--- a/src/backend/ActionsList/index.js
+++ b/src/backend/ActionsList/index.js
@@ -7,6 +7,11 @@ const { readCache } = require('../lib/statsCache');
 
 const CACHE_MAX_AGE_SECONDS = 300; // 5 minutes
 
+// Azure Table Storage rejects a `maxPageSize` above 1000 entities. Callers may
+// still ask for a larger `limit`; we satisfy it by fetching several pages of at
+// most this size and accumulating until `limit` entities are collected.
+const MAX_TABLE_PAGE_SIZE = 1000;
+
 // Encodes an opaque continuation value (string, number, or object) into a
 // URL-safe cursor for clients to pass back on the next request.
 function encodeCursor(continuationToken) {
@@ -58,9 +63,11 @@ module.exports = async function actionsList(context, req) {
     ? String(req.query.owner)
     : (context.bindingData && context.bindingData.owner);
 
-  // Parse limit parameter. When provided, it also acts as the page size for
-  // cursor-based pagination (see `cursor` below) and the response is wrapped
-  // as `{ items, nextCursor }`. When omitted, the full result set is returned
+  // Parse limit parameter. When provided, it is the maximum number of entities
+  // returned by this request (see `cursor` below) and the response is wrapped
+  // as `{ items, nextCursor }`. Any positive limit is honoured, including ones
+  // above the Table Storage page cap, which are served as multiple pages
+  // internally. When omitted, the full result set is returned
   // as a plain array, preserving the historic behaviour relied on by callers
   // that need the complete dataset in one shot (e.g. the frontend's
   // background full fetch, or the E2E test harness).
@@ -168,19 +175,45 @@ module.exports = async function actionsList(context, req) {
     }
 
     if (limit !== null) {
-      // Cursor-based pagination: fetch a single page of `limit` entities using
-      // Azure Table Storage's continuation token, instead of scanning the
-      // whole table and slicing in memory.
-      const pageSettings = { maxPageSize: limit };
-      if (continuationToken !== undefined) {
-        pageSettings.continuationToken = continuationToken;
+      // Cursor-based pagination: fetch entities using Azure Table Storage's
+      // continuation token, instead of scanning the whole table and slicing in
+      // memory. Table Storage caps a page at MAX_TABLE_PAGE_SIZE entities, and
+      // may also return a short page while still having more to give, so keep
+      // pulling pages until `limit` entities are collected or the table is
+      // exhausted. Each page requests only as many entities as are still
+      // needed, so the continuation token we hand back always points exactly
+      // after the last entity we returned.
+      const pageEntities = [];
+      let pageToken = continuationToken;
+
+      while (pageEntities.length < limit) {
+        const remaining = limit - pageEntities.length;
+        const pageSettings = { maxPageSize: Math.min(remaining, MAX_TABLE_PAGE_SIZE) };
+        if (pageToken !== undefined) {
+          pageSettings.continuationToken = pageToken;
+        }
+
+        const pageIterator = tableClient.listEntities(queryOptions).byPage(pageSettings);
+        const { value: page } = await pageIterator.next();
+        const batch = page || [];
+        pageEntities.push(...batch);
+
+        const previousToken = pageToken;
+        pageToken = page && page.continuationToken;
+
+        // Stop once the table has nothing more to give. The zero-progress check
+        // guards against a page that returns no entities without advancing the
+        // token, which would otherwise spin forever.
+        if (pageToken === undefined || pageToken === null || pageToken === '') {
+          break;
+        }
+        if (batch.length === 0 && pageToken === previousToken) {
+          break;
+        }
       }
 
-      const pageIterator = tableClient.listEntities(queryOptions).byPage(pageSettings);
-      const { value: page } = await pageIterator.next();
-      const pageEntities = page || [];
       const results = pageEntities.map(entityToActionInfo).filter(Boolean);
-      const nextCursor = encodeCursor(page && page.continuationToken);
+      const nextCursor = encodeCursor(pageToken);
 
       const headers = {
         'X-Actions-Count': results.length,

--- a/src/backend/tests/actionsList.test.js
+++ b/src/backend/tests/actionsList.test.js
@@ -161,6 +161,19 @@ describe('ActionsList function', () => {
     expect(context.res.body.nextCursor).toBeNull();
   });
 
+  test('should accept limit values above the Table Storage page cap', async () => {
+    const entities = createTestEntities(1200);
+    getTableClient.mockReturnValue(createFakeTableClient(entities));
+
+    for (const limit of ['1000', '1001', '100000']) {
+      const context = createContext();
+      await actionsList(context, { method: 'GET', query: { limit }, headers: {} });
+
+      expect(context.res.status).toBe(200);
+      expect(context.res.body.items).toHaveLength(Math.min(parseInt(limit, 10), 1200));
+    }
+  });
+
   test('should handle OPTIONS request', async () => {
     const context = createContext();
     const req = {
@@ -277,9 +290,17 @@ describe('ActionsList real table client path', () => {
   // Mimics the shape of the @azure/data-tables PagedAsyncIterableIterator:
   // both a plain async iterable (`for await`) and a `.byPage()` page iterator
   // that carries a `continuationToken` on each returned page.
+  // Azure Table Storage rejects a maxPageSize above this and the SDK surfaces
+  // it as a request error, which is exactly what produced the 500 for large
+  // `limit` values.
+  const MAX_TABLE_PAGE_SIZE = 1000;
+
   function createRealStyleTableClient(entities, throwError) {
+    const requestedPageSizes = [];
+
     return {
       url: 'https://real.table.core.windows.net/actions',
+      requestedPageSizes,
       listEntities() {
         return {
           async *[Symbol.asyncIterator]() {
@@ -289,6 +310,15 @@ describe('ActionsList real table client path', () => {
             }
           },
           byPage(settings = {}) {
+            if (settings.maxPageSize !== undefined) {
+              requestedPageSizes.push(settings.maxPageSize);
+              if (settings.maxPageSize > MAX_TABLE_PAGE_SIZE) {
+                throw new Error(
+                  `The value specified for the maxPageSize (${settings.maxPageSize}) is invalid.`
+                );
+              }
+            }
+
             const maxPageSize = settings.maxPageSize || entities.length || 1;
             let startIndex = 0;
             if (settings.continuationToken !== undefined) {
@@ -429,6 +459,114 @@ describe('ActionsList real table client path', () => {
 
     expect(context.res.status).toBe(200);
     expect(context.res.body).toHaveLength(1);
+  });
+
+  test('honours a limit exactly at the Table Storage page cap in a single page', async () => {
+    const entities = Array.from({ length: 1500 }, (_, i) =>
+      createTestEntity('org', `action${i}`)
+    );
+    const client = createRealStyleTableClient(entities);
+    getTableClient.mockReturnValue(client);
+
+    const context = createContext();
+    await actionsList(context, { method: 'GET', query: { limit: '1000' }, headers: {} });
+
+    expect(context.res.status).toBe(200);
+    expect(context.res.body.items).toHaveLength(1000);
+    expect(context.res.body.nextCursor).toBeTruthy();
+    expect(client.requestedPageSizes).toEqual([1000]);
+  });
+
+  test('honours a limit just above the page cap by fetching multiple pages', async () => {
+    const entities = Array.from({ length: 1500 }, (_, i) =>
+      createTestEntity('org', `action${i}`)
+    );
+    const client = createRealStyleTableClient(entities);
+    getTableClient.mockReturnValue(client);
+
+    const context = createContext();
+    await actionsList(context, { method: 'GET', query: { limit: '1001' }, headers: {} });
+
+    expect(context.res.status).toBe(200);
+    expect(context.res.body.items).toHaveLength(1001);
+    expect(context.res.body.items[0].name).toBe('action0');
+    expect(context.res.body.items[1000].name).toBe('action1000');
+    expect(context.res.body.nextCursor).toBeTruthy();
+    // Pages of at most 1000, second page asking only for what is still needed.
+    expect(client.requestedPageSizes).toEqual([1000, 1]);
+  });
+
+  test('honours a limit far above the page cap without exceeding maxPageSize', async () => {
+    const entities = Array.from({ length: 5200 }, (_, i) =>
+      createTestEntity('org', `action${i}`)
+    );
+    const client = createRealStyleTableClient(entities);
+    getTableClient.mockReturnValue(client);
+
+    const context = createContext();
+    await actionsList(context, { method: 'GET', query: { limit: '50000' }, headers: {} });
+
+    expect(context.res.status).toBe(200);
+    // Table exhausted before the limit was reached, so everything is returned.
+    expect(context.res.body.items).toHaveLength(5200);
+    expect(context.res.body.nextCursor).toBeNull();
+    expect(Math.max(...client.requestedPageSizes)).toBeLessThanOrEqual(1000);
+  });
+
+  test('a large limit resumes correctly from a cursor', async () => {
+    const entities = Array.from({ length: 3000 }, (_, i) =>
+      createTestEntity('org', `action${i}`)
+    );
+    const client = createRealStyleTableClient(entities);
+    getTableClient.mockReturnValue(client);
+
+    const firstContext = createContext();
+    await actionsList(firstContext, { method: 'GET', query: { limit: '1200' }, headers: {} });
+    expect(firstContext.res.body.items).toHaveLength(1200);
+    const cursor = firstContext.res.body.nextCursor;
+    expect(cursor).toBeTruthy();
+
+    const secondContext = createContext();
+    await actionsList(secondContext, {
+      method: 'GET',
+      query: { limit: '1200', cursor },
+      headers: {}
+    });
+
+    expect(secondContext.res.status).toBe(200);
+    expect(secondContext.res.body.items).toHaveLength(1200);
+    // Picks up exactly where the previous page stopped - no gap, no overlap.
+    expect(secondContext.res.body.items[0].name).toBe('action1200');
+    expect(secondContext.res.body.items[1199].name).toBe('action2399');
+  });
+
+  test('keeps pulling pages when the table returns a short page with a continuation token', async () => {
+    // Table Storage may cut a page short (server-side time limit) while still
+    // having more entities to give.
+    const entities = Array.from({ length: 30 }, (_, i) =>
+      createTestEntity('org', `action${i}`)
+    );
+    const client = createRealStyleTableClient(entities);
+    const originalListEntities = client.listEntities.bind(client);
+    client.listEntities = (options) => {
+      const iterable = originalListEntities(options);
+      const originalByPage = iterable.byPage.bind(iterable);
+      // Force every page to be capped at 5 entities regardless of what was asked for.
+      iterable.byPage = (settings = {}) =>
+        originalByPage({ ...settings, maxPageSize: Math.min(settings.maxPageSize || 5, 5) });
+      return iterable;
+    };
+    getTableClient.mockReturnValue(client);
+
+    const context = createContext();
+    await actionsList(context, { method: 'GET', query: { limit: '12' }, headers: {} });
+
+    expect(context.res.status).toBe(200);
+    expect(context.res.body.items).toHaveLength(12);
+    expect(context.res.body.items.map(a => a.name)).toEqual(
+      Array.from({ length: 12 }, (_, i) => `action${i}`)
+    );
+    expect(context.res.body.nextCursor).toBeTruthy();
   });
 
   test('returns 500 when listEntities throws', async () => {


### PR DESCRIPTION
## What

`GET /api/actions/list?limit=N` returned HTTP 500 `{"error":"Failed to query actions from table storage."}` for any `N > 1000`.

```bash
curl -s "https://func-wsg6po7n4p5dg.azurewebsites.net/api/actions/list?limit=1000"  # works
curl -s "https://func-wsg6po7n4p5dg.azurewebsites.net/api/actions/list?limit=1001"  # 500
```

## Why

The cursor-pagination branch in `src/backend/ActionsList/index.js` passed the caller's `limit` straight through as `pageSettings.maxPageSize`. Azure Table Storage rejects a `maxPageSize` above 1000; the resulting SDK error was swallowed by the generic `try`/`catch` and reported as a generic 500.

## How

Rather than capping the caller's `limit` (which would change the API contract), the handler now keeps requesting pages of at most 1000 entities and accumulates until `limit` items are collected or the table is exhausted.

- Added `MAX_TABLE_PAGE_SIZE = 1000`.
- Each iteration requests `maxPageSize: Math.min(remaining, 1000)` — asking only for what is still needed means the continuation token handed back always points **exactly** after the last entity returned, so there is no gap or overlap when the caller resumes with the cursor.
- The `{ items, nextCursor }` response shape is unchanged, and any positive `limit` is honoured with no caller-visible cap.
- A zero-progress guard prevents spinning if a page returns no entities without advancing the token.

### Bonus fix

The loop also handles Table Storage returning a **short page while more data remains** (server-side time limit). The previous single-`next()` read would have silently truncated the response in that case.

## Tests

`src/backend/tests/actionsList.test.js` — the real-style mock client now records every `maxPageSize` it is asked for and **throws** on anything above 1000, reproducing the actual Azure failure rather than assuming it.

New cases:

- `limit=1000` → single page, exactly one request of size 1000
- `limit=1001` → 1001 items, page sizes `[1000, 1]`
- `limit=50000` against 5200 entities → all 5200 returned, `nextCursor: null`, no page request over 1000
- `limit=1200` twice via cursor → second page starts at `action1200`, no gap or overlap
- short-page-with-continuation-token → keeps pulling until `limit` is satisfied
- fake in-memory client path at 1000 / 1001 / 100000

Verified the tests bite: stashing the fix makes 4 of them fail; restoring it makes them pass.

## Verification

`npm test` from `src/backend`: **261 passed, 20 suites**.

`npm run lint` reports **0 problems in the files changed here**, but exits 1 on two pre-existing `no-unused-vars` errors in `ActionsReadme/index.js:43` and `lib/readmeAssets.js:29`. Both files are untouched by this diff and were last modified in #223 — left alone as out of scope.

## Note for reviewers

The production `curl` reproduction above was not re-run to confirm the fix, since this branch is not deployed yet. Worth a quick check against `?limit=1001` once it ships.

🤖 Generated with [Claude Code](https://claude.com/claude-code)