### PR TITLE
Fix no-unused-vars lint errors in ActionsReadme and readmeAssets

### DIFF
--- a/src/backend/ActionsReadme/index.js
+++ b/src/backend/ActionsReadme/index.js
@@ -40,7 +40,7 @@ async function fetchReadmePath(url, headers) {
     }
     const data = await response.json();
     return data && typeof data.path === 'string' ? data.path : null;
-  } catch (error) {
+  } catch {
     return null;
   }
 }

--- a/src/backend/lib/readmeAssets.js
+++ b/src/backend/lib/readmeAssets.js
@@ -26,7 +26,7 @@ function isAbsoluteUrl(url) {
 function resolveRelativeUrl(relativeUrl, baseUrl) {
   try {
     return new URL(relativeUrl, baseUrl).toString();
-  } catch (error) {
+  } catch {
     return relativeUrl;
   }
 }


### PR DESCRIPTION
## Summary
- `src/backend/ActionsReadme/index.js` and `src/backend/lib/readmeAssets.js` each had a `catch (error)` block where `error` was never used, tripping ESLint's `no-unused-vars` rule (`caughtErrorsIgnorePattern: "^_"`).
- Switched both to optional catch binding syntax (`catch {`), matching the existing convention already used elsewhere in the backend (e.g. `ActionsReadme/index.js`'s `getRepoUpdatedAt`, `ActionsList/index.js`).

## Test plan
- [x] `npm test` — 20 suites, 255 tests, all passing
- [x] `npm run lint` — clean, no errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)