### PR TITLE
Group Dependabot updates per npm ecosystem

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -33,6 +33,10 @@ updates:
       - dependencies
     commit-message:
       prefix: "deps(frontend)"
+    groups:
+      frontend:
+        patterns:
+          - "*"
 
   - package-ecosystem: npm
     directory: /src/backend
@@ -45,6 +49,10 @@ updates:
       - dependencies
     commit-message:
       prefix: "deps(backend)"
+    groups:
+      backend:
+        patterns:
+          - "*"
 
   - package-ecosystem: npm
     directory: /src/mcp-server
@@ -57,6 +65,10 @@ updates:
       - dependencies
     commit-message:
       prefix: "deps(mcp)"
+    groups:
+      mcp:
+        patterns:
+          - "*"
 
   - package-ecosystem: npm
     directory: /vscode-extension
@@ -69,6 +81,10 @@ updates:
       - dependencies
     commit-message:
       prefix: "deps(vscode)"
+    groups:
+      vscode:
+        patterns:
+          - "*"
     ignore:
       # typescript-eslint only supports TypeScript below 6.1; a bump past that
       # breaks `npm ci` on a peer dependency conflict rather than failing a test.


### PR DESCRIPTION
We currently get one Dependabot PR per npm dependency bump, which creates a lot of noise across the `frontend`, `backend`, `mcp-server`, and `vscode-extension` workspaces. This change groups all npm updates in each workspace into a single weekly PR instead.

- Adds a catch-all `groups` block to each npm ecosystem entry in `.github/dependabot.yml`.
- Keeps the existing GitHub Actions grouping untouched, since that is already working well.
- Keeps existing schedules, labels, commit-message prefixes, and the `vscode-extension` ignore rules.

The YAML syntax was validated locally before committing.