### PR TITLE
Make action cards and back button openable in new tabs

### DIFF
--- a/src/frontend/src/App.css
+++ b/src/frontend/src/App.css
@@ -403,6 +403,8 @@ body {
   border-radius: var(--r-lg);
   padding: 0;
   cursor: pointer;
+  text-decoration: none;
+  color: inherit;
   transition: border-color var(--t), box-shadow var(--t), transform var(--t);
   box-shadow: var(--shadow-sm);
   display: flex;
@@ -730,6 +732,7 @@ body {
   gap: 6px;
   padding: 8px 14px;
   margin-bottom: 20px;
+  text-decoration: none;
   background: var(--c-surface);
   border: 1.5px solid var(--c-border-strong);
   border-radius: var(--r-md);

--- a/src/frontend/src/pages/DetailPage.tsx
+++ b/src/frontend/src/pages/DetailPage.tsx
@@ -17,7 +17,18 @@ export const DetailPage: React.FC = () => {
   const [readmeLoading, setReadmeLoading] = useState(false);
   const [readmeError, setReadmeError] = useState<string | null>(null);
 
-  const handleBack = () => {
+  const backHref = typeof document !== 'undefined' ? document.referrer || '/' : '/';
+
+  const handleBack = (event?: React.MouseEvent) => {
+    if (event) {
+      const isModifiedClick = event.ctrlKey || event.metaKey || event.shiftKey || event.altKey || event.button !== 0;
+      if (isModifiedClick) {
+        // Let the browser open the <a href> in a new tab/window.
+        return;
+      }
+      event.preventDefault();
+    }
+
     if (window.history.length > 1) {
       navigate(-1);
       return;
@@ -131,9 +142,9 @@ export const DetailPage: React.FC = () => {
   if (error || !action) {
     return (
       <div className="app">
-        <button className="back-button" onClick={handleBack}>
+        <a className="back-button" href={backHref} onClick={e => handleBack(e)}>
           ← Back to Overview
-        </button>
+        </a>
         <div className="error-message">{error || 'Action not found'}</div>
       </div>
     );
@@ -148,9 +159,9 @@ export const DetailPage: React.FC = () => {
         <p>Browse and search through GitHub Actions with more information</p>
       </div>
 
-      <button className="back-button" onClick={handleBack}>
+      <a className="back-button" href={backHref} onClick={e => handleBack(e)}>
         ← Back to Overview
-      </button>
+      </a>
 
       <div className="detail-page">
         <div className="detail-header">

--- a/src/frontend/src/pages/OverviewPage.tsx
+++ b/src/frontend/src/pages/OverviewPage.tsx
@@ -363,7 +363,18 @@ export const OverviewPage: React.FC = () => {
   const hiddenByFilters = Math.max(0, actions.length - filteredActions.length);
   const hasActiveFilters = hiddenByFilters > 0;
 
-  const handleActionClick = (action: Action) => {
+  const handleActionClick = (action: Action, event?: React.MouseEvent) => {
+    const detailUrl = `/action/${encodeURIComponent(action.owner)}/${encodeURIComponent(action.name)}`;
+
+    if (event) {
+      const isModifiedClick = event.ctrlKey || event.metaKey || event.shiftKey || event.altKey || event.button !== 0;
+      if (isModifiedClick) {
+        // Let the browser open the <a href> in a new tab/window.
+        return;
+      }
+      event.preventDefault();
+    }
+
     writeOverviewState({
       searchQuery,
       typeFilter,
@@ -374,7 +385,7 @@ export const OverviewPage: React.FC = () => {
       currentPage,
       scrollY: window.scrollY
     });
-    navigate(`/action/${encodeURIComponent(action.owner)}/${encodeURIComponent(action.name)}`);
+    navigate(detailUrl);
   };
 
   const getActionTypeBadgeClass = (type: string) => {
@@ -624,10 +635,11 @@ export const OverviewPage: React.FC = () => {
         <>
           <div className="actions-grid">
             {pagedActions.map(action => (
-              <div
+              <a
                 key={`${action.owner}/${action.name}`}
                 className={`action-card ${action.repoInfo?.archived ? 'archived' : ''}`}
-                onClick={() => handleActionClick(action)}
+                href={`/action/${encodeURIComponent(action.owner)}/${encodeURIComponent(action.name)}`}
+                onClick={e => handleActionClick(action, e)}
               >
                 <div className="action-header">
                   <div className="action-title">
@@ -692,7 +704,7 @@ export const OverviewPage: React.FC = () => {
                     </span>
                   </div>
                 </div>
-              </div>
+              </a>
             ))}
           </div>
 


### PR DESCRIPTION
Users want to open action details (and the back button) in a new browser tab with Ctrl/Cmd/Middle-click, just like any other link. The current cards and back button use click handlers that only support in-page navigation.

Changes:
- Convert action cards in `OverviewPage.tsx` from `<div onClick>` to `<a href>` so the browser can open them in a new tab on modified clicks. Plain left-click still writes the overview filter/scroll state to `sessionStorage` and navigates in-page.
- Convert the `DetailPage` back button from `<button onClick>` to `<a href>` using `document.referrer || '/'` as the href. Plain left-click still calls `history.back()` when history exists; modified clicks open the referrer in a new tab.
- Add `text-decoration: none` and `color: inherit` to `.action-card` and `.back-button` so the new anchors keep the existing visual style.

Verified with `npm run build` in `/src/frontend`.