### PR TITLE
fix(vscode): move F5 launch config to repo root so it actually loads

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,11 +16,11 @@ local.settings.json
 .azurite/
 
 # Editor and tooling
-.vscode/
-# The extension's own launch config is part of its development setup, not a
-# personal editor preference, so it is tracked.
-!vscode-extension/.vscode/
-!vscode-extension/.vscode/launch.json
+.vscode/*
+# The F5 launch/build configs are part of this repo's development setup, not a
+# personal editor preference, so they are tracked.
+!.vscode/launch.json
+!.vscode/tasks.json
 .vs/
 .DS_Store
 Thumbs.db

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -7,7 +7,15 @@
       "request": "launch",
       "args": ["--extensionDevelopmentPath=${workspaceFolder}/vscode-extension"],
       "outFiles": ["${workspaceFolder}/vscode-extension/dist/**/*.js"],
-      "preLaunchTask": "npm: build"
+      "preLaunchTask": "vscode-extension: build"
+    },
+    {
+      "name": "Launch Marketplace Website",
+      "type": "chrome",
+      "request": "launch",
+      "url": "http://localhost:3000",
+      "webRoot": "${workspaceFolder}/src/frontend",
+      "preLaunchTask": "frontend: dev server"
     }
   ]
 }

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,0 +1,41 @@
+{
+  "version": "2.0.0",
+  "tasks": [
+    {
+      "label": "vscode-extension: build",
+      "type": "npm",
+      "script": "build",
+      "path": "vscode-extension",
+      "problemMatcher": [],
+      "presentation": {
+        "reveal": "silent"
+      },
+      "group": "build"
+    },
+    {
+      "label": "frontend: dev server",
+      "type": "npm",
+      "script": "dev",
+      "path": "src/frontend",
+      "isBackground": true,
+      "problemMatcher": {
+        "owner": "vite",
+        "pattern": {
+          "regexp": "^$",
+          "file": 1,
+          "location": 2,
+          "message": 3
+        },
+        "background": {
+          "activeOnStart": true,
+          "beginsPattern": "VITE",
+          "endsPattern": "Local:"
+        }
+      },
+      "presentation": {
+        "reveal": "always",
+        "panel": "dedicated"
+      }
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

- The extension's `launch.json` lived at `vscode-extension/.vscode/launch.json`, but VS Code only reads `.vscode/launch.json` at the root of the opened workspace folder — it never scans nested subfolders unless that subfolder is itself opened as the workspace root. Since the [README](vscode-extension/README.md) tells contributors to press F5 from the repository root, this config was dead on arrival.
- Moved `launch.json` to the repo root (`.vscode/launch.json`) and added `.vscode/tasks.json` with an explicit `vscode-extension: build` task — needed because both `src/frontend` and `vscode-extension` have a `build` script, which makes VS Code's auto-detected `npm: build` task label ambiguous.
- Added a second F5 option, "Launch Marketplace Website", which starts the Vite dev server (`src/frontend`) as a background task and opens it in Chrome, so the F5 picker now offers both "debug the extension" and "run the website locally".
- Updated `.gitignore` to track the root `.vscode/launch.json` and `tasks.json` instead of the old nested carve-out for `vscode-extension/.vscode/launch.json`.

## Test plan

- [x] `npm run build` in `vscode-extension` succeeds (verified locally)
- [x] `npm run dev` in `src/frontend` starts the Vite dev server and prints the expected `VITE ... ready` / `Local:` output the background task's problem matcher watches for
- [ ] Open the repo root in VS Code and confirm F5 shows both "Run Extension" and "Launch Marketplace Website", and that each one launches correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)