### PR TITLE
vscode: clarify AI tool usage and external 'Open details' links

### DIFF
--- a/vscode-extension/src/ui/dashboardHtml.ts
+++ b/vscode-extension/src/ui/dashboardHtml.ts
@@ -153,6 +153,25 @@ export function getDashboardHtml(webview: vscode.Webview): string {
   button.secondary:hover { background: var(--vscode-button-secondaryHoverBackground); }
 
   .hidden { display: none !important; }
+
+  .example { margin-bottom: 10px; }
+  .example:last-child { margin-bottom: 0; }
+
+  .example-label {
+    font-weight: 600;
+    font-size: 0.9em;
+    margin-bottom: 3px;
+  }
+
+  .example-prompt {
+    display: block;
+    font-family: var(--vscode-editor-font-family);
+    font-size: 0.85em;
+    background: var(--vscode-textCodeBlock-background, var(--vscode-editorWidget-background));
+    border-radius: 4px;
+    padding: 6px 8px;
+    white-space: pre-wrap;
+  }
 </style>
 </head>
 <body>
@@ -174,6 +193,17 @@ export function getDashboardHtml(webview: vscode.Webview): string {
     <button id="explorer" type="button">Open Marketplace Explorer</button>
     <button id="search" class="secondary" type="button">Search Actions&hellip;</button>
     <button id="website" class="secondary" type="button">Open State of Actions website</button>
+  </div>
+
+  <h2>Use with AI</h2>
+  <p class="subtitle">This extension gives AI agents (e.g. GitHub Copilot Chat) tools to look up real marketplace data, so answers use current versions instead of guesses from the model's training data.</p>
+  <div class="example">
+    <div class="example-label">Always look up the latest version</div>
+    <code class="example-prompt">Before pinning actions/checkout in my workflow, look up its latest version and commit SHA.</code>
+  </div>
+  <div class="example">
+    <div class="example-label">Audit all your workflows</div>
+    <code class="example-prompt">Check every action used in .github/workflows against the marketplace and flag any that are outdated, unverified, or archived.</code>
   </div>
 
 <script nonce="${nonce}">

--- a/vscode-extension/src/ui/panelHtml.ts
+++ b/vscode-extension/src/ui/panelHtml.ts
@@ -88,8 +88,16 @@ export function getPanelHtml(webview: vscode.Webview): string {
     padding: 0;
     border: none;
     text-decoration: none;
+    display: inline-flex;
+    align-items: center;
+    gap: 4px;
   }
   button.link:hover { text-decoration: underline; background: none; }
+
+  .icon-external {
+    flex: none;
+    fill: currentColor;
+  }
 
   .stats {
     display: grid;
@@ -288,6 +296,19 @@ export function getPanelHtml(webview: vscode.Webview): string {
 
   const number = (value) => (typeof value === 'number' ? value.toLocaleString('en-US') : '-');
 
+  function externalLinkIcon() {
+    const svg = document.createElementNS('http://www.w3.org/2000/svg', 'svg');
+    svg.setAttribute('class', 'icon-external');
+    svg.setAttribute('viewBox', '0 0 16 16');
+    svg.setAttribute('width', '12');
+    svg.setAttribute('height', '12');
+    svg.setAttribute('aria-hidden', 'true');
+    const path = document.createElementNS('http://www.w3.org/2000/svg', 'path');
+    path.setAttribute('d', 'M10 1h5v5h-1.5V3.56L7.06 10 6 8.94 12.44 2.5H10V1zM3 3h4v1.5H3v8.5h8.5V9H13v5.5H1.5V3H3z');
+    svg.appendChild(path);
+    return svg;
+  }
+
   function card(value, label, detail) {
     const node = document.createElement('div');
     node.className = 'card';
@@ -444,7 +465,8 @@ export function getPanelHtml(webview: vscode.Webview): string {
       const openButton = document.createElement('button');
       openButton.type = 'button';
       openButton.className = 'link';
-      openButton.textContent = 'Open details';
+      openButton.title = 'Opens ' + row.url + ' in your browser';
+      openButton.append('Open details', externalLinkIcon());
       openButton.addEventListener('click', () => {
         vscodeApi.postMessage({ type: 'open', url: row.url });
       });


### PR DESCRIPTION
## Summary
- Marketplace explorer panel: the "Open details" link now shows a small external-link icon and a tooltip (`Opens <url> in your browser`) so it's clear it navigates to the action's website rather than opening something inside the extension.
- Activity bar dashboard: added a "Use with AI" section beneath the Quick links that explains the extension's registered AI tools, with two example prompts — always checking an action's latest version before pinning it, and auditing every action referenced across `.github/workflows`.

## Test plan
- [x] `npm run check-types`
- [x] `npm run lint`
- [x] `npx vitest run` (142 tests passing)
- [x] Rendered both webview templates standalone (served over a local HTTP server with a VS Code webview API stub) to confirm the "Use with AI" section appears in the right place and the "Open details" button renders the icon/tooltip as expected.