### PR TITLE
Add description field to action feeds for keyword search

### DIFF
--- a/Decision Records/description-search.md
+++ b/Decision Records/description-search.md
@@ -1,0 +1,74 @@
+# Keyword Search Beyond Owner/Name
+
+## Context
+
+Search in both the VS Code extension's Marketplace Explorer and the website's
+overview page matched only `owner` and `name`. A query like "docker" or "lint"
+found nothing unless that word happened to appear in a repo or action name,
+even though most actions describe what they do in their `action.yml`
+`description` field. `description` is a documented top-level field in the raw
+payload schema ([src/backend/README.md](../src/backend/README.md#action-data-schema)) and
+round-trips through `ActionRecord` today, but nothing in this repo populates
+it - the crawler that reads `action.yml` from GitHub repos and uploads
+records is an external pipeline, out of this repo.
+
+## Decision
+
+Two independent changes:
+
+### 1. Fold already-available facets into free-text search
+
+`actionType`, `verified`, and `archived` were already carried by both wire
+formats ([lib/versionsBuilder.js](../src/backend/lib/versionsBuilder.js) for the extension,
+[lib/actionSummary.js](../src/backend/lib/actionSummary.js) for the website) but were filter-only,
+never part of the searchable text. Both `ActionIndex.search`
+(`vscode-extension/src/data/actionIndex.ts`) and the website's
+`matchesSearchQuery` (`src/frontend/src/services/utils.ts`) now fold owner,
+name, action type, and the literal tokens `verified`/`archived` (when set)
+into one normalized string, and match every query token against it. This
+needed no backend change and no schema version bump.
+
+### 2. Add `description` to both projections
+
+`description` is appended to `VERSIONS_FIELDS` in `versionsBuilder.js` and to
+the summary shape in `actionSummary.js`, trimmed and capped at 200 characters
+(`DESCRIPTION_MAX_LENGTH` in both files) - a one-line blurb is enough for
+search and display, and mirrors the "no full version history" scoping
+decision in [action-versions-feed.md](action-versions-feed.md). This is a pure append to
+the positional `versions` feed, so per that feed's own convention it does not
+require a `VERSIONS_SCHEMA_VERSION` bump.
+
+Both extractors read `payload.description` directly and report `null` when
+absent or blank - **null means "unknown," not "no description,"** the same
+convention `latestSha` already uses for the ~half of the dataset with no
+resolvable commit SHA. Search and the UI must not distinguish "empty" from
+"not sent yet."
+
+Consumers:
+- The extension's `snapshot.ts` decodes `description` as an optional field
+  (not in `REQUIRED_FIELDS`, so an older server response without it still
+  decodes cleanly) and `actionIndex.ts` folds it into the searchable text
+  alongside owner/name/type.
+- The website's `Action` type gained an optional `description`, folded into
+  `matchesSearchQuery` the same way.
+
+### Population responsibility
+
+Populating `description` is out of scope for this repo. The external crawler
+that uploads action records needs to parse `description` out of each
+repository's `action.yml` and include it in the upsert payload - the same
+"external indexer populates it" split used for `versionShaMap`
+([version-sha-map.md](version-sha-map.md)). Until that lands, every row's `description`
+is `null` and search behaves exactly as it did before this change, degrading
+gracefully rather than erroring.
+
+## Rejected alternative
+
+Bumping `VERSIONS_SCHEMA_VERSION` for the new field. Unnecessary: per the
+feed's own convention (see `versionsBuilder.js`), appending a field at the end
+of the positional row is backwards compatible - only reordering or removing a
+field requires a version bump.
+
+## Status
+
+Accepted

--- a/src/backend/lib/actionSummary.js
+++ b/src/backend/lib/actionSummary.js
@@ -11,6 +11,28 @@
 //
 // When the overview or state pages start reading a new field, add it here —
 // otherwise it will silently be `undefined` in the snapshot.
+//
+// `description` is the one exception to "only what the UI renders": it's
+// carried purely so the overview's free-text search can match on it, same as
+// owner/name. It's null for effectively the whole dataset until the ingest
+// pipeline starts populating it.
+
+// Long enough for a useful search/display blurb, short enough not to inflate
+// the snapshot - mirrors lib/versionsBuilder.js's DESCRIPTION_MAX_LENGTH.
+const DESCRIPTION_MAX_LENGTH = 200;
+
+function readDescription(payload) {
+  if (typeof payload.description !== 'string') {
+    return null;
+  }
+  const trimmed = payload.description.trim();
+  if (!trimmed) {
+    return null;
+  }
+  return trimmed.length > DESCRIPTION_MAX_LENGTH
+    ? `${trimmed.slice(0, DESCRIPTION_MAX_LENGTH - 1).trimEnd()}…`
+    : trimmed;
+}
 
 // Reads the OpenSSF score from any of the casings that have appeared in the
 // pipeline data over time. Returns null when there is no usable numeric score.
@@ -114,6 +136,7 @@ function toActionSummary(payload) {
     },
     dependents: { dependents: dependentsCount },
     releaseInfo: readLatestRelease(payload),
+    description: readDescription(payload),
     verified: readVerified(payload),
     ossf: payload.ossf === true || ossfScore !== null,
     ossfScore: ossfScore === null ? 0 : ossfScore,

--- a/src/backend/lib/versionsBuilder.js
+++ b/src/backend/lib/versionsBuilder.js
@@ -6,7 +6,8 @@
  * for a client (e.g. the VS Code extension) to download on a daily refresh.
  * This projection keeps only what a consumer needs to answer "what is the
  * latest version of this action, when was it published, and which commit SHA
- * does it point at" plus the handful of facets worth filtering on.
+ * does it point at" plus the handful of facets worth filtering on, plus a short
+ * description for keyword search (null until the ingest pipeline populates it).
  *
  * Not to be confused with `lib/actionSummary.js`, which projects the same table
  * for the frontend overview. That one carries the fields the UI renders and
@@ -34,13 +35,18 @@ const VERSIONS_FIELDS = [
   'flags',
   'ossfScore',
   'dependents',
-  'floatingTags'
+  'floatingTags',
+  'description'
 ];
 
 const FLAG_VERIFIED = 1;
 const FLAG_ARCHIVED = 2;
 const FLAG_OSSF = 4;
 const FLAG_DISABLED = 8;
+
+// Long enough for a useful search/display blurb, short enough to not inflate
+// the feed - action.yml descriptions are one-liners in practice.
+const DESCRIPTION_MAX_LENGTH = 200;
 
 // Floating tags are the ones humans actually pin in workflows: `v4`, `v4.1`.
 // Immutable patch tags (`v4.1.2`) are already covered by `latestVersion`, and
@@ -210,6 +216,29 @@ function parseDependents(value) {
   return Number.isFinite(parsed) ? parsed : null;
 }
 
+/**
+ * Normalizes the action's description for the feed.
+ *
+ * The ingest pipeline does not populate this field yet, so it is null for
+ * effectively the whole dataset today - callers must treat null as "unknown",
+ * not "no description", the same convention `latestSha` already uses.
+ *
+ * @param {*} value
+ * @returns {string|null}
+ */
+function normalizeDescription(value) {
+  if (typeof value !== 'string') {
+    return null;
+  }
+  const trimmed = value.trim();
+  if (!trimmed) {
+    return null;
+  }
+  return trimmed.length > DESCRIPTION_MAX_LENGTH
+    ? `${trimmed.slice(0, DESCRIPTION_MAX_LENGTH - 1).trimEnd()}…`
+    : trimmed;
+}
+
 function normalizeOssfScore(payload) {
   const raw = payload.openssf_score ?? payload.ossfScore ?? payload.ossf_score ?? null;
   if (typeof raw === 'number' && Number.isFinite(raw)) {
@@ -277,6 +306,7 @@ function buildRow(payload) {
   const flags = computeFlags(payload, ossfScore);
   const dependents = parseDependents(payload.dependents && payload.dependents.dependents);
   const floatingTags = collectFloatingTags(tagShaMap);
+  const description = normalizeDescription(payload.description);
 
   return [
     owner,
@@ -290,7 +320,8 @@ function buildRow(payload) {
     dependents,
     // 0 rather than [] or null: it is the cheapest "nothing here" marker in JSON
     // and this field is empty for the majority of rows.
-    floatingTags.length > 0 ? floatingTags : 0
+    floatingTags.length > 0 ? floatingTags : 0,
+    description
   ];
 }
 
@@ -371,7 +402,9 @@ module.exports = {
   buildTagShaMap,
   collectFloatingTags,
   normalizeVersionEntry,
+  normalizeDescription,
   parseDependents,
   resolveLatestVersion,
-  stripOwnerPrefix
+  stripOwnerPrefix,
+  DESCRIPTION_MAX_LENGTH
 };

--- a/src/backend/tests/actionSummary.test.js
+++ b/src/backend/tests/actionSummary.test.js
@@ -8,6 +8,7 @@ describe('toActionSummary', () => {
     repoInfo: { updated_at: '2026-07-20T10:00:00Z', archived: false, disabled: false },
     dependents: { dependents: '1,000', dependentsLastUpdated: '2026-07-01' },
     releaseInfo: ['v4.2.0', 'v4.1.0'],
+    description: 'Checkout a Git repository so a workflow can access it',
     verified: true,
     ossf: true,
     openssf_score: 8.4,
@@ -29,6 +30,7 @@ describe('toActionSummary', () => {
       repoInfo: { updated_at: '2026-07-20T10:00:00Z', archived: false },
       dependents: { dependents: '1,000' },
       releaseInfo: ['v4.2.0'],
+      description: 'Checkout a Git repository so a workflow can access it',
       verified: true,
       ossf: true,
       ossfScore: 8.4,
@@ -125,5 +127,21 @@ describe('toActionSummary', () => {
     const summary = toActionSummary({ owner: '  actions  ', name: '  checkout  ' });
     expect(summary.owner).toBe('actions');
     expect(summary.name).toBe('checkout');
+  });
+
+  it('reports null when the pipeline has not populated a description yet', () => {
+    expect(toActionSummary({ owner: 'o', name: 'n' }).description).toBeNull();
+    expect(toActionSummary({ owner: 'o', name: 'n', description: '   ' }).description).toBeNull();
+    expect(toActionSummary({ owner: 'o', name: 'n', description: 42 }).description).toBeNull();
+  });
+
+  it('trims a description and truncates it to 200 characters', () => {
+    expect(toActionSummary({ owner: 'o', name: 'n', description: '  Lint your Dockerfiles  ' }).description)
+      .toBe('Lint your Dockerfiles');
+
+    const long = 'x'.repeat(250);
+    const summary = toActionSummary({ owner: 'o', name: 'n', description: long });
+    expect(summary.description).toHaveLength(200);
+    expect(summary.description.endsWith('…')).toBe(true);
   });
 });

--- a/src/backend/tests/versionsBuilder.test.js
+++ b/src/backend/tests/versionsBuilder.test.js
@@ -10,6 +10,7 @@ const {
   buildTagShaMap,
   collectFloatingTags,
   normalizeVersionEntry,
+  normalizeDescription,
   parseDependents,
   resolveLatestVersion,
   stripOwnerPrefix
@@ -315,6 +316,41 @@ describe('buildRow', () => {
     expect(row[FIELD.actionType]).toBeNull();
     expect(row[FIELD.dependents]).toBeNull();
     expect(row[FIELD.flags]).toBe(0);
+  });
+
+  it('projects the description, trimmed', () => {
+    const row = buildRow({ ...fullPayload, description: '  Checkout a Git repository  ' });
+    expect(row[FIELD.description]).toBe('Checkout a Git repository');
+  });
+
+  it('reports a null description when the pipeline has not sent one', () => {
+    // This is the common case today: the ingest pipeline doesn't populate
+    // description yet, so every row reports null - "unknown", not "none".
+    expect(buildRow(fullPayload)[FIELD.description]).toBeNull();
+  });
+});
+
+describe('normalizeDescription', () => {
+  it('trims whitespace', () => {
+    expect(normalizeDescription('  Lint your Dockerfiles  ')).toBe('Lint your Dockerfiles');
+  });
+
+  it('treats blank or non-string values as null', () => {
+    expect(normalizeDescription('   ')).toBeNull();
+    expect(normalizeDescription(undefined)).toBeNull();
+    expect(normalizeDescription(null)).toBeNull();
+    expect(normalizeDescription(42)).toBeNull();
+  });
+
+  it('truncates to 200 characters with an ellipsis', () => {
+    const result = normalizeDescription('x'.repeat(250));
+    expect(result).toHaveLength(200);
+    expect(result.endsWith('…')).toBe(true);
+  });
+
+  it('leaves a description at exactly the limit untouched', () => {
+    const exact = 'x'.repeat(200);
+    expect(normalizeDescription(exact)).toBe(exact);
   });
 });
 


### PR DESCRIPTION
## Summary
- Appends `description` (trimmed, capped at 200 chars) to the positional `versions` feed (`versionsBuilder.js`, append-only, no schema version bump needed) and to the website's overview snapshot (`actionSummary.js`)
- Both extractors report `null`/missing when the field is absent — the external crawler doesn't populate `description` yet, so this is structural groundwork with no behavior change until it does
- Adds `Decision Records/description-search.md` documenting the choice, following the format of `action-versions-feed.md`

## Related
This is one of three companion PRs for the same feature (search matching beyond owner/name):
- #TBD extension: `feat/extension-keyword-search`
- #TBD website: `feat/website-keyword-search`

Independently mergeable in any order — the other two PRs already handle a missing `description` gracefully.

## Test plan
- [x] `cd src/backend && npm test` — 402/402 passing
- [x] `npx eslint lib/versionsBuilder.js lib/actionSummary.js tests/versionsBuilder.test.js tests/actionSummary.test.js` — clean