### PR TITLE
Search actions by type, verified/archived state, and description

### DIFF
--- a/vscode-extension/package.json
+++ b/vscode-extension/package.json
@@ -170,13 +170,13 @@
           "search"
         ],
         "userDescription": "Search the alternative GitHub Actions marketplace dataset.",
-        "modelDescription": "Search the alternative GitHub Actions marketplace for actions matching a query, when you need to find an action to do a job rather than resolve a version you already know. Matches on owner and repository name; every whitespace-separated token in the query must appear somewhere in 'owner name'. Results are ordered by dependent count, so the most widely used matches come first, and each result carries the latest version, commit SHA, action type, archived state, and OpenSSF score. Optional filters narrow by action type (Node, Docker, Composite), owner, verified status, and whether archived actions are included. Prefer recommending non-archived actions with many dependents.",
+        "modelDescription": "Search the alternative GitHub Actions marketplace for actions matching a query, when you need to find an action to do a job rather than resolve a version you already know. Matches on owner, repository name, action type, verified/archived state, and description (when known); every whitespace-separated token in the query must appear somewhere in that combined text. Results are ordered by dependent count, so the most widely used matches come first, and each result carries the latest version, commit SHA, action type, archived state, and OpenSSF score. Optional filters narrow by action type (Node, Docker, Composite), owner, verified status, and whether archived actions are included. Prefer recommending non-archived actions with many dependents.",
         "inputSchema": {
           "type": "object",
           "properties": {
             "query": {
               "type": "string",
-              "description": "Free text to match against owner and action name, for example \"terraform lint\" or \"setup node\"."
+              "description": "Free text to match against owner, action name, type, and description, for example \"terraform lint\" or \"docker build\"."
             },
             "actionType": {
               "type": "string",

--- a/vscode-extension/src/data/actionIndex.ts
+++ b/vscode-extension/src/data/actionIndex.ts
@@ -85,6 +85,22 @@ export function tokenizeQuery(query: string): string[] {
   return normalizeSearchable(query).split(/\s+/).filter(Boolean);
 }
 
+/**
+ * Builds the text a query is matched against for one entry: owner, name, type,
+ * verified/archived state, and description - everything a user might type to
+ * find an action by what it does rather than just what it's called.
+ */
+function buildSearchableText(entry: ActionEntry): string {
+  const parts = [entry.owner, entry.name, entry.actionType, entry.description];
+  if (entry.verified) {
+    parts.push('verified');
+  }
+  if (entry.archived) {
+    parts.push('archived');
+  }
+  return normalizeSearchable(parts.filter(Boolean).join(' '));
+}
+
 function actionUrl(owner: string, name: string): string {
   return `https://marketplace.devopsjournal.io/action/${encodeURIComponent(owner)}/${encodeURIComponent(name)}`;
 }
@@ -108,7 +124,7 @@ export class ActionIndex {
     this.schemaVersion = snapshot.schemaVersion;
     this.indexed = snapshot.entries.map((entry) => ({
       entry,
-      searchable: normalizeSearchable(`${entry.owner} ${entry.name}`)
+      searchable: buildSearchableText(entry)
     }));
 
     for (const { entry } of this.indexed) {
@@ -322,8 +338,9 @@ export class ActionIndex {
   }
 
   /**
-   * Token search over `owner name`, matching the website's behaviour: every
-   * token in the query must appear somewhere in the normalized text.
+   * Token search over owner, name, type, verified/archived state, and
+   * description, matching the website's behaviour: every token in the query
+   * must appear somewhere in the normalized text.
    */
   search(query: string, filters: SearchFilters = {}): ActionSearchResult[] {
     const tokens = tokenizeQuery(query);

--- a/vscode-extension/src/data/snapshot.ts
+++ b/vscode-extension/src/data/snapshot.ts
@@ -37,6 +37,8 @@ export interface ActionEntry {
   /** Publish date of the repository's latest release, ISO 8601. */
   publishedAt: string | null;
   actionType: string | null;
+  /** Short blurb from the action's `action.yml`. Null when not yet ingested. */
+  description: string | null;
   verified: boolean;
   archived: boolean;
   disabled: boolean;
@@ -157,6 +159,7 @@ export function decodeSnapshot(raw: unknown): DecodedSnapshot {
       latestSha: asString(row[index.latestSha]),
       publishedAt: asString(row[index.publishedAt]),
       actionType: asString(row[index.actionType]),
+      description: asString(row[index.description]),
       verified: (flags & ActionFlag.Verified) !== 0,
       archived: (flags & ActionFlag.Archived) !== 0,
       disabled: (flags & ActionFlag.Disabled) !== 0,

--- a/vscode-extension/src/ui/panelHtml.ts
+++ b/vscode-extension/src/ui/panelHtml.ts
@@ -260,7 +260,7 @@ export function getPanelHtml(webview: vscode.Webview): string {
 
   <section aria-label="Search">
     <div class="controls">
-      <input id="query" type="text" placeholder="Search by owner or action name, e.g. setup node" autocomplete="off" spellcheck="false" />
+      <input id="query" type="text" placeholder="Search by owner, name, type, or keyword, e.g. docker lint" autocomplete="off" spellcheck="false" />
       <select id="type" aria-label="Action type">
         <option value="">All types</option>
         <option value="Node">Node</option>

--- a/vscode-extension/test/actionIndex.test.ts
+++ b/vscode-extension/test/actionIndex.test.ts
@@ -198,6 +198,25 @@ describe('ActionIndex.search', () => {
   it('includes a marketplace url for each result', () => {
     expect(index.search('checkout')[0].url).toBe('https://marketplace.devopsjournal.io/action/actions/checkout');
   });
+
+  it('matches a free-text query against the action type', () => {
+    expect(index.search('composite').map((item) => item.ref)).toEqual(['someone/no-releases']);
+  });
+
+  it('matches a free-text query against verified and archived state', () => {
+    expect(index.search('verified').map((item) => item.ref)).toEqual(['actions/setup-node']);
+    expect(index.search('archived', { includeArchived: true }).map((item) => item.ref))
+      .toEqual(['someone/abandoned-action']);
+  });
+
+  it('matches a free-text query against the description', () => {
+    expect(index.search('terraform').map((item) => item.ref)).toEqual(['someone/no-releases']);
+    expect(index.search('lints configuration').map((item) => item.ref)).toEqual(['someone/no-releases']);
+  });
+
+  it('still matches by owner/name when an entry has no description', () => {
+    expect(index.search('checkout').map((item) => item.ref)).toEqual(['actions/checkout']);
+  });
 });
 
 describe('ActionIndex.stats', () => {

--- a/vscode-extension/test/helpers.ts
+++ b/vscode-extension/test/helpers.ts
@@ -11,7 +11,8 @@ export const SNAPSHOT_FIELDS = [
   'flags',
   'ossfScore',
   'dependents',
-  'floatingTags'
+  'floatingTags',
+  'description'
 ];
 
 export interface RowInput {
@@ -25,6 +26,7 @@ export interface RowInput {
   ossfScore?: number | null;
   dependents?: number | null;
   floatingTags?: Array<[string, string]> | 0;
+  description?: string | null;
 }
 
 export function row(input: RowInput): unknown[] {
@@ -38,7 +40,8 @@ export function row(input: RowInput): unknown[] {
     input.flags ?? 0,
     input.ossfScore ?? null,
     input.dependents ?? null,
-    input.floatingTags ?? 0
+    input.floatingTags ?? 0,
+    input.description ?? null
   ];
 }
 
@@ -113,6 +116,7 @@ export const SAMPLE_ROWS: RowInput[] = [
     latestSha: null,
     actionType: 'Composite',
     flags: 0,
-    dependents: 0
+    dependents: 0,
+    description: 'Lints Terraform configuration files before apply'
   }
 ];

--- a/vscode-extension/test/snapshot.test.ts
+++ b/vscode-extension/test/snapshot.test.ts
@@ -16,7 +16,8 @@ describe('decodeSnapshot', () => {
         flags: 1 | 4,
         ossfScore: 6.9,
         dependents: 15368157,
-        floatingTags: [['v7', SHA_CHECKOUT_LATEST]]
+        floatingTags: [['v7', SHA_CHECKOUT_LATEST]],
+        description: 'Checkout a Git repository'
       }
     ]));
 
@@ -34,7 +35,8 @@ describe('decodeSnapshot', () => {
       hasOssf: true,
       ossfScore: 6.9,
       dependents: 15368157,
-      floatingTags: { v7: SHA_CHECKOUT_LATEST }
+      floatingTags: { v7: SHA_CHECKOUT_LATEST },
+      description: 'Checkout a Git repository'
     });
   });
 
@@ -81,6 +83,21 @@ describe('decodeSnapshot', () => {
     expect(entry.ossfScore).toBeNull();
     expect(entry.dependents).toBeNull();
     expect(entry.floatingTags).toEqual({});
+    expect(entry.description).toBeNull();
+  });
+
+  it('decodes a snapshot with no "description" field at all as null on every entry', () => {
+    // The field is optional and won't exist until the ingest pipeline sends it -
+    // an old server response must still decode cleanly.
+    const decoded = decodeSnapshot({
+      schemaVersion: 1,
+      generatedAt: '2026-07-26T04:30:00.000Z',
+      count: 1,
+      fields: ['owner', 'name', 'latestVersion', 'latestSha'],
+      actions: [['actions', 'checkout', 'v7.0.1', SHA_CHECKOUT_LATEST]]
+    });
+
+    expect(decoded.entries[0].description).toBeNull();
   });
 
   it('skips rows without an owner or name instead of producing broken entries', () => {


### PR DESCRIPTION
## Summary
Marketplace Explorer search only matched `owner` and `name`, so a query like "docker" or "lint" found nothing unless that word happened to be in a repo/action name.

- `ActionIndex.search` now also matches action type, the literal tokens `verified`/`archived`, and `description` (decoded as an optional field — forward-compatible with today's feed, which doesn't send it yet)
- Updates the search box placeholder text
- Updates the `searchActions` language model tool's `modelDescription`/`query` docs, which explicitly documented the old owner/name-only matching behavior

## Related
Companion PR: #254 (backend, adds the `description` field to the versions feed this extension reads). Independently mergeable — until #254 ships, `description` decodes to `null` on every row and search behavior is exactly what it was before this PR (owner/name/type/verified/archived only).

Also companion to `feat/website-keyword-search` (same change, website side).

## Test plan
- [x] `cd vscode-extension && npx vitest run` — 147/147 passing
- [x] `npx tsc --noEmit -p tsconfig.json` — clean
- [x] `npx eslint src test` — clean