### PR TITLE
Search actions by type, verified/archived state, and description

### DIFF
--- a/src/frontend/src/pages/OverviewPage.tsx
+++ b/src/frontend/src/pages/OverviewPage.tsx
@@ -230,7 +230,14 @@ export const OverviewPage: React.FC = () => {
 
     const normalizedQuery = deferredSearchQuery.trim();
     if (normalizedQuery) {
-      filtered = filtered.filter(action => matchesSearchQuery({ owner: action.owner, name: action.name }, normalizedQuery));
+      filtered = filtered.filter(action => matchesSearchQuery({
+        owner: action.owner,
+        name: action.name,
+        actionType: action.actionType?.actionType,
+        verified: isActionVerified(action),
+        archived: action.repoInfo?.archived,
+        description: action.description
+      }, normalizedQuery));
     }
 
     if (typeFilter !== 'All') {
@@ -493,7 +500,7 @@ export const OverviewPage: React.FC = () => {
         <div className="search-box">
           <input
             type="text"
-            placeholder="Search by action name or owner..."
+            placeholder="Search by name, owner, type, or keyword..."
             value={searchQuery}
             onChange={e => setSearchQuery(e.target.value)}
           />

--- a/src/frontend/src/services/utils.ts
+++ b/src/frontend/src/services/utils.ts
@@ -19,15 +19,33 @@ export function normalizeRepoName(owner?: string, name?: string) {
 
 export default { splitOwnerRepo, normalizeRepoName };
 
-export function matchesSearchQuery(item: { owner?: string; name?: string }, rawQuery?: string) {
+export interface SearchableAction {
+  owner?: string;
+  name?: string;
+  actionType?: string;
+  verified?: boolean;
+  archived?: boolean;
+  description?: string | null;
+}
+
+// Kept in lockstep with the VS Code extension's ActionIndex.search matching
+// logic (vscode-extension/src/data/actionIndex.ts) so a query typed on the
+// website returns the same matches as the same query in the extension.
+export function matchesSearchQuery(item: SearchableAction, rawQuery?: string) {
   if (!rawQuery) return true;
   const q = String(rawQuery).trim().toLowerCase();
   if (!q) return true;
 
-  // Normalize searchable text: owner + name, replace non-alphanum with spaces
+  // Normalize searchable text: owner, name, type, verified/archived state,
+  // and description, replace non-alphanum with spaces
   const owner = String(item.owner || '').toLowerCase();
   const name = String(item.name || '').toLowerCase();
-  const searchable = `${owner} ${name}`.replace(/[^a-z0-9]+/g, ' ').trim();
+  const actionType = String(item.actionType || '').toLowerCase();
+  const description = String(item.description || '').toLowerCase();
+  const flags = [item.verified ? 'verified' : '', item.archived ? 'archived' : ''].join(' ');
+  const searchable = `${owner} ${name} ${actionType} ${flags} ${description}`
+    .replace(/[^a-z0-9]+/g, ' ')
+    .trim();
 
   // Normalize query: replace non-alphanum with space and split tokens
   const tokens = q.replace(/[^a-z0-9]+/g, ' ').split(/\s+/).filter(Boolean);

--- a/src/frontend/src/types/Action.ts
+++ b/src/frontend/src/types/Action.ts
@@ -25,6 +25,8 @@ export interface Action {
   };
   tagInfo: string[];
   releaseInfo: string[];
+  /** Short blurb from the action's action.yml. Null until the ingest pipeline populates it. */
+  description?: string | null;
   versionShaMap?: Record<string, string>;
   dependabotEnabled: boolean;
   mirrorLastUpdated: string | null;

--- a/src/frontend/tests/utils.spec.ts
+++ b/src/frontend/tests/utils.spec.ts
@@ -21,4 +21,29 @@ test.describe('matchesSearchQuery unit tests', () => {
     const item = { owner: 'Test-Org', name: 'my_repo-name' };
     expect(matchesSearchQuery(item, 'test org my repo')).toBe(true);
   });
+
+  test('matches a query against the action type', () => {
+    const item = { owner: 'actions', name: 'checkout', actionType: 'Docker' };
+    expect(matchesSearchQuery(item, 'docker')).toBe(true);
+    expect(matchesSearchQuery(item, 'node')).toBe(false);
+  });
+
+  test('matches a query against verified and archived state', () => {
+    const verified = { owner: 'actions', name: 'checkout', verified: true };
+    const archived = { owner: 'actions', name: 'old-thing', archived: true };
+    expect(matchesSearchQuery(verified, 'verified')).toBe(true);
+    expect(matchesSearchQuery(archived, 'archived')).toBe(true);
+    expect(matchesSearchQuery(verified, 'archived')).toBe(false);
+  });
+
+  test('matches a query against the description', () => {
+    const item = { owner: 'someone', name: 'no-releases', description: 'Lints Terraform configuration files' };
+    expect(matchesSearchQuery(item, 'terraform')).toBe(true);
+    expect(matchesSearchQuery(item, 'lints configuration')).toBe(true);
+  });
+
+  test('still matches by owner/name when description is missing', () => {
+    const item = { owner: 'actions', name: 'checkout' };
+    expect(matchesSearchQuery(item, 'checkout')).toBe(true);
+  });
 });


### PR DESCRIPTION
## Summary
Mirrors the VS Code extension's search improvement (#255) on the website's overview page. `matchesSearchQuery` only matched `owner` and `name`; it now also matches action type, verified/archived state, and `description` (a new optional `Action` field), keeping the two implementations' matching logic in lockstep as the code already intends.

## Related
Companion PR: #254 (backend, adds `description` to the `/api/actions/snapshot` projection this page reads). Independently mergeable — until #254 ships, `description` is `undefined` on every action and search behavior is exactly what it was before this PR.

Also companion to #255 (same change, extension side).

## Test plan
- [x] `npx tsc --noEmit` — clean
- [x] `npx playwright test tests/utils.spec.ts` — 8/8 passing